### PR TITLE
move db fixtures to shared library

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq" // Load PostgresSQL Driver
+
+	"github.com/circleci/ex/config/secret"
+	"github.com/circleci/ex/o11y"
+)
+
+type Config struct {
+	Host string
+	Port int
+	User string
+	Pass secret.String
+	Name string
+	SSL  bool
+}
+
+func New(ctx context.Context, dbName, appName string, options Config) (db *sqlx.DB, err error) {
+	_, span := o11y.StartSpan(ctx, "config: connect to database")
+	defer o11y.End(span, &err)
+
+	host := fmt.Sprintf("%s:%d", options.Host, options.Port)
+
+	span.AddField("database", dbName)
+	span.AddField("host", host)
+	span.AddField("dbname", options.Name)
+	span.AddField("username", options.User)
+
+	params := url.Values{}
+	params.Set("connect_timeout", "5")
+	params.Set("application_name", appName)
+	if options.SSL {
+		params.Set("sslmode", "require")
+	} else {
+		params.Set("sslmode", "disable")
+	}
+	uri := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(options.User, options.Pass.Value()),
+		Host:     host,
+		Path:     options.Name,
+		RawQuery: params.Encode(),
+	}
+	db, err = sqlx.Open("postgres", uri.String())
+	if err != nil {
+		return nil, err
+	}
+
+	db.SetConnMaxLifetime(time.Hour)
+	// Chosen based on production metrics (during spikes in db io lag) to minimise waiting whilst protecting
+	// the db server from possibly problematic load.
+	db.SetMaxOpenConns(100)
+	db.SetMaxIdleConns(50)
+	return db, nil
+}

--- a/db/error.go
+++ b/db/error.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/lib/pq"
+
+	"github.com/circleci/ex/o11y"
+)
+
+var (
+	ErrNop         = o11y.NewWarning("no update or results")
+	ErrConstrained = errors.New("violates constraints")
+	ErrException   = errors.New("exception")
+	ErrCanceled    = o11y.NewWarning("statement canceled")
+)
+
+const (
+	pgForeignKeyConstraintErrorCode = "23503"
+	pgUniqueViolationErrorCode      = "23505"
+	pgExceptionRaised               = "P0001"
+	pgStatementCanceled             = "57014"
+)
+
+func mapExecErrors(err error, res sql.Result) error {
+	found, err := mapError(err)
+	if found {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNop
+	}
+	return nil
+}
+
+// mapError maps a few pq errors to a errors defined in this package, some wrapping the original
+// error. If a mapping was made the returned bool will be true, if not the original error is returned and
+// the bool will be false.
+// nolint: golint - error, bool is fine for error mapping funcs
+func mapError(err error) (bool, error) {
+	e := &pq.Error{}
+	if errors.As(err, &e) {
+		switch e.Code {
+		case pgForeignKeyConstraintErrorCode:
+			return true, ErrConstrained
+		case pgExceptionRaised:
+			return true, fmt.Errorf("%w: %s", ErrException, e.Message)
+		case pgStatementCanceled:
+			return true, fmt.Errorf("%w: %s", ErrCanceled, e.Message)
+		case pgUniqueViolationErrorCode:
+			return true, fmt.Errorf("%w: %s", ErrNop, e.Message)
+		}
+	}
+	return false, err
+}

--- a/db/error_test.go
+++ b/db/error_test.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lib/pq"
+	"gotest.tools/v3/assert"
+
+	"github.com/circleci/ex/o11y"
+)
+
+func TestMapError(t *testing.T) {
+	err := &pq.Error{
+		Code: "57014",
+	}
+	ok, e := mapError(err)
+	assert.Assert(t, ok)
+	assert.Assert(t, o11y.IsWarning(e))
+	e = fmt.Errorf("foo: %w", e)
+	assert.Assert(t, o11y.IsWarning(e))
+}

--- a/db/like.go
+++ b/db/like.go
@@ -1,0 +1,10 @@
+package db
+
+import "strings"
+
+func EscapeLike(s string) string {
+	return strings.NewReplacer(
+		"_", `\_`,
+		"%", `\%`,
+	).Replace(s)
+}

--- a/db/like_test.go
+++ b/db/like_test.go
@@ -1,0 +1,21 @@
+package db
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestEscapeLike(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{in: "im good", out: "im good"},
+		{in: "im na_ght_y", out: `im na\_ght\_y`},
+		{in: "per%ent", out: `per\%ent`},
+		{in: "_im%rly %b_d", out: `\_im\%rly \%b\_d`},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, EscapeLike(tt.in), tt.out)
+	}
+}

--- a/db/o11y.go
+++ b/db/o11y.go
@@ -1,0 +1,20 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/circleci/ex/o11y"
+)
+
+// Recommendations for naming here are taken from
+// https://github.com/open-telemetry/opentelemetry-specification/blob/7ae3d066c95c716ef3086228ef955d84ba03ac88/specification/trace/semantic_conventions/database.md
+
+func Span(ctx context.Context, entity, queryName string) (context.Context, o11y.Span) {
+	ctx, span := o11y.StartSpan(ctx, fmt.Sprintf("db: %s.%s", entity, queryName))
+	span.RecordMetric(o11y.Timing("db.query", "db.entity", "db.query_name", "result"))
+	span.AddRawField("db.system", "postgresql")
+	span.AddRawField("db.entity", entity)
+	span.AddRawField("db.query_name", queryName)
+	return ctx, span
+}

--- a/db/querier.go
+++ b/db/querier.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+)
+
+// Querier can either be a *sqlx.DB or *sqlx.Tx
+type Querier interface {
+	// The following are implemented by sql.DB, sql.Tx
+
+	// ExecContext executes the query with placeholder parameters that match the args.
+	// Use this if the query does not use named parameters (for that use NamedExecContext),
+	// and you do not care about the data the query generates.
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+
+	// The following are implemented by sqlx.DB, sqlx.Tx
+
+	// GetContext expects placeholder parameters in the query and will bind args to them.
+	// A single row result will be mapped to dest which must be a pointer to a struct.
+	// In the case of no result the error returned will be sql.ErrNoRows.
+	GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+
+	// NamedGetContext expect a query with named parameters, fields from the arg struct will be mapped
+	// to the named parameters. A single row result will be mapped to dest which must be a pointer to a struct.
+	//NamedGetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+
+	// NamedExecContext expect a query with named parameters, fields from the arg struct will be mapped
+	// to the named parameters. Use this if you do not care about the data the query generates, and
+	// you don't want to use placeholder parameters (see ExecContext)
+	NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)
+
+	// SelectContext expects placeholder parameters in the query and will bind args to them.
+	// Each resultant row will be scanned into dest, which must be a slice.
+	// (If you expect (or want) a single row in the response use GetContext instead.)
+	// This method never returns sql.ErrNoRows, instead the dest slice will be empty.
+	SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+}

--- a/db/transactions.go
+++ b/db/transactions.go
@@ -1,0 +1,69 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/circleci/ex/o11y"
+)
+
+func NewTransactionManager(db *sqlx.DB) *TxManager {
+	return &TxManager{DB: db}
+}
+
+type TxManager struct {
+	DB *sqlx.DB
+	// This is only for testing purposes
+	TestQuerier func(Querier) Querier
+}
+
+func (s *TxManager) WithTransaction(ctx context.Context, f func(context.Context, Querier) error) (err error) {
+	ctx, span := o11y.StartSpan(ctx, "tx-manager: with-transaction")
+	defer o11y.End(span, &err)
+
+	tx, err := s.DB.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("could not start transaction: %w", err)
+	}
+
+	defer func() {
+		p := recover()
+		switch {
+		case p != nil:
+			// a panic occurred, rollback and re-panic
+			_ = tx.Rollback()
+			panic(p)
+		case err != nil:
+			// never commit on an error
+			// but don't rollback if the transaction context has been canceled
+			// (the library code already handles rollback in the context canceled cases)
+			if ctx.Err() == context.Canceled {
+				return
+			}
+			// something other than a context cancel went wrong, rollback
+			if rErr := tx.Rollback(); rErr != nil {
+				o11y.AddField(ctx, "rollback_error", rErr)
+			}
+		case ctx.Err() == context.Canceled:
+			// f may have suppressed an error but the transaction has still been cancelled
+			// even if f appeared to have not seen any error we report the context cancellation
+			// so the client will at least be able to be aware that the transaction was rolled back
+			err = ctx.Err()
+			return
+		default:
+			// all good, commit
+			err = tx.Commit()
+		}
+	}()
+
+	var q Querier = unifiedTx{tx: tx}
+	if s.TestQuerier != nil {
+		q = s.TestQuerier(tx)
+	}
+	err = f(ctx, q)
+
+	// Note that the above defer can reassign err
+	return err
+}

--- a/db/transactions_test.go
+++ b/db/transactions_test.go
@@ -1,0 +1,120 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"gotest.tools/v3/assert"
+
+	"github.com/circleci/ex/o11y"
+)
+
+func TestNoEffectError(t *testing.T) {
+	var err error
+
+	err = ErrNop
+	assert.Assert(t, o11y.IsWarning(err))
+
+	err = fmt.Errorf("some other error: %w", err)
+	assert.Assert(t, o11y.IsWarning(err))
+
+	err = fmt.Errorf("another error: %w", err)
+	assert.Assert(t, errors.Is(err, ErrNop))
+	assert.Assert(t, o11y.IsWarning(err))
+}
+
+func TestTransactionManager_ContextCancelled_WithError(t *testing.T) {
+	ourError := errors.New("our error")
+	tests := []struct {
+		returnError error
+		cancel      bool
+		commits     int
+		rollbacks   int
+		expectError error
+	}{
+		{returnError: nil, cancel: false, expectError: nil, commits: 1},
+		{returnError: nil, cancel: true, expectError: context.Canceled, rollbacks: 1},
+		{returnError: ourError, cancel: false, expectError: ourError, rollbacks: 1},
+		// the sqlx transaction wrapper sees the context cancel so does not call commit
+		// but if the commit is called in our tx manager it will return context.Canceled and not ourError
+		{returnError: ourError, cancel: true, expectError: ourError, rollbacks: 1},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("err-%v-cancel-%t", tt.returnError, tt.cancel), func(t *testing.T) {
+			ttx := &fakeTx{}
+			tx := NewTransactionManager(sqlx.NewDb(sql.OpenDB(fakeConnector{tx: ttx}), "fake"))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := tx.WithTransaction(ctx, func(ctx context.Context, _ Querier) error {
+				if tt.cancel {
+					cancel()
+				}
+				if tt.returnError != nil {
+					return tt.returnError
+				}
+				return nil
+			})
+			if tt.expectError != nil {
+				assert.Assert(t, errors.Is(err, tt.expectError), "got:%v wanted:%v", err, tt.expectError)
+			} else {
+				assert.NilError(t, err)
+			}
+			ttx.mu.Lock()
+			defer ttx.mu.Unlock()
+			assert.Equal(t, ttx.rollBackCount, tt.rollbacks)
+			assert.Equal(t, ttx.commitCount, tt.commits)
+		})
+	}
+}
+
+type fakeConnector struct {
+	driver.Connector
+	tx *fakeTx
+}
+
+func (c fakeConnector) Connect(context.Context) (driver.Conn, error) {
+	return fakeConn{tx: c.tx}, nil
+}
+
+type fakeConn struct {
+	tx *fakeTx
+	driver.Conn
+}
+
+func (c fakeConn) Begin() (driver.Tx, error) {
+	// to simulate the transaction lifecycle
+	// will be unlocked in Commit or Rollback
+	c.tx.mu.Lock()
+	return c.tx, nil
+}
+
+func (c fakeConn) Close() error {
+	return nil
+}
+
+type fakeTx struct {
+	// to simulate a transaction a bit and because the
+	// actual rollback calls are async in the stdlib (or sqlx) code
+	mu            sync.Mutex
+	commitCount   int
+	rollBackCount int
+}
+
+func (tx *fakeTx) Commit() error {
+	tx.commitCount++
+	defer tx.mu.Unlock()
+	return nil
+}
+
+func (tx *fakeTx) Rollback() error {
+	tx.rollBackCount++
+	tx.mu.Unlock()
+	return nil
+}

--- a/db/unified_tx.go
+++ b/db/unified_tx.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"reflect"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// unifiedTx wraps the Querier subset of methods of the standard sqlx.DB with helpers to return our standard
+// errors.
+type unifiedTx struct {
+	tx *sqlx.Tx
+}
+
+func (u unifiedTx) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	result, err := u.tx.ExecContext(ctx, query, args...)
+	return result, mapExecErrors(err, result)
+}
+
+func (u unifiedTx) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	err := u.tx.GetContext(ctx, dest, query, args...)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNop
+	}
+	_, err = mapError(err)
+	return err
+}
+
+func (u unifiedTx) NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
+	result, err := u.tx.NamedExecContext(ctx, query, arg)
+	return result, mapExecErrors(err, result)
+}
+
+func (u unifiedTx) SelectContext(ctx context.Context,
+	dest interface{}, query string, args ...interface{}) error {
+
+	if err := u.tx.SelectContext(ctx, dest, query, args...); err != nil {
+		_, err = mapError(err)
+		return err // This error never represents the no rows condition
+	}
+	// SelectContext has asserted dest is a pointer to a slice
+	value := reflect.ValueOf(dest)
+	direct := reflect.Indirect(value)
+	if direct.Len() == 0 {
+		return ErrNop
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,9 @@ require (
 	github.com/honeycombio/beeline-go v1.1.2
 	github.com/honeycombio/dynsampler-go v0.2.1
 	github.com/honeycombio/libhoney-go v1.15.3
+	github.com/jmoiron/sqlx v1.3.4
 	github.com/klauspost/compress v1.13.1
+	github.com/lib/pq v1.10.2
 	github.com/rollbar/rollbar-go v1.4.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	gotest.tools/v3 v3.0.3

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7a
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/attrs v0.1.0/go.mod h1:fmNpaWyHM0tRm8gCZWKx8yY9fvaNLo2PyzBNSrBZ5Hw=
@@ -179,6 +180,7 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
+github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
 github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -214,6 +216,8 @@ github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
+github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/luna-duclos/instrumentedsql v1.1.3/go.mod h1:9J1njvFds+zN7y85EDhN9XNQLANWwZt2ULeIC8yMNYs=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/markbates/errx v1.1.0/go.mod h1:PLa46Oex9KNbVDZhKel8v1OT7hD5JZ2eI7AHhA0wswc=
@@ -232,6 +236,7 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=


### PR DESCRIPTION
In setting up db components for machine-provisioner noticed that was doing a lot of copy pasta with pieces that are shared with distributor. Believe this will help remove some of the duplication in setting up new services.