### PR TITLE
take in app name for running kong help tests

### DIFF
--- a/testing/kongtest/kongtest.go
+++ b/testing/kongtest/kongtest.go
@@ -9,11 +9,11 @@ import (
 	"gotest.tools/v3/assert/cmp"
 )
 
-func Help(t *testing.T, cli interface{}) string {
+func Help(t *testing.T, cli interface{}, appName string) string {
 	w := bytes.NewBuffer(nil)
 	exited := false
 	app, err := kong.New(cli,
-		kong.Name("test-app"),
+		kong.Name(appName),
 		kong.Writers(w, w),
 		kong.Exit(func(int) {
 			exited = true

--- a/testing/kongtest/kongtest_test.go
+++ b/testing/kongtest/kongtest_test.go
@@ -18,7 +18,7 @@ func TestHelp(t *testing.T) {
 	}
 
 	c := cli{}
-	s := Help(t, &c)
+	s := Help(t, &c, "test-app")
 	assert.Check(t, golden.String(s, "help.txt"))
 	assert.Check(t, cmp.Equal(c, cli{
 		StringVar:   "string-default",


### PR DESCRIPTION
Currently the app name is hard coded to `test-app`, this PR changes the test helper to take the name of the app so golden files can be used directly from the output of --help instead of having to be modified to use the hard coded value. 