### PR TITLE
Add datadog client library

### DIFF
--- a/datadog/client.go
+++ b/datadog/client.go
@@ -1,0 +1,238 @@
+package datadog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type Client struct {
+	APIKey     string
+	AppKey     string
+	BaseURL    *url.URL
+	HTTPClient *http.Client
+}
+
+var ErrHTTP = errors.New("datadog HTTP error")
+
+func (c *Client) Validate(ctx context.Context) (valid bool, err error) {
+	u := &url.URL{Path: "validate"}
+
+	var resp struct {
+		IsValid bool `json:"valid"`
+	}
+	err = c.doGet(ctx, u, &resp, nil)
+	if err != nil {
+		return false, err
+	}
+
+	return resp.IsValid, nil
+}
+
+var ErrInvalidQuery = errors.New("invalid query")
+
+type QueryParams struct {
+	From, To time.Time
+	Query    string
+}
+
+type QueryResponse struct {
+	Series []Series
+	Meta   ResponseMetadata
+}
+
+func (c *Client) Query(ctx context.Context, q QueryParams) (response QueryResponse, err error) {
+	v := url.Values{}
+	v.Add("from", strconv.FormatInt(q.From.Unix(), 10))
+	v.Add("to", strconv.FormatInt(q.To.Unix(), 10))
+	v.Add("query", q.Query)
+	u := &url.URL{Path: "query", RawQuery: v.Encode()}
+
+	var resp struct {
+		Status string   `json:"status"`
+		Error  string   `json:"error"`
+		Series []Series `json:"series,omitempty"`
+	}
+	err = c.doGet(ctx, u, &resp, &response.Meta)
+	if err != nil {
+		return response, err
+	}
+
+	if resp.Status != "ok" {
+		return response, fmt.Errorf("%w: %s", ErrInvalidQuery, resp.Error)
+	}
+
+	response.Series = resp.Series
+	return response, nil
+}
+
+type Series struct {
+	Metric      string      `json:"metric"`
+	DisplayName string      `json:"display_name"`
+	Points      []DataPoint `json:"pointlist"`
+	Start       UnixTime    `json:"start"`
+	End         UnixTime    `json:"end"`
+	Interval    int         `json:"interval"`
+	Aggr        string      `json:"aggr"`
+	Length      int         `json:"length"`
+	Scope       string      `json:"scope"`
+	Expression  string      `json:"expression"`
+}
+
+// DataPoint is a tuple of UNIX timestamp, value. It has custom
+// JSON serialisation to allow variadic decoding of the JSON array.
+type DataPoint struct {
+	Time  UnixTime
+	Value float64
+}
+
+func (d DataPoint) String() string {
+	return fmt.Sprintf("{Time:%s, Value:%f}", d.Time, d.Value)
+}
+
+func (d *DataPoint) UnmarshalJSON(b []byte) (err error) {
+	arr := []interface{}{&d.Time, &d.Value}
+	err = json.Unmarshal(b, &arr)
+	if err != nil {
+		return fmt.Errorf("failed to decode data point: %w", err)
+	}
+	return nil
+}
+
+type UnixTime struct {
+	time.Time
+}
+
+// UnmarshalJSON converts from milliseconds since the epoch
+func (t *UnixTime) UnmarshalJSON(b []byte) (err error) {
+	ms, err := strconv.ParseFloat(string(b), 64)
+	if err != nil {
+		return fmt.Errorf("failed to decode unix time: %w", err)
+	}
+	t.Time = time.Unix(0, int64(ms*1e6))
+	return nil
+}
+
+type ResponseMetadata struct {
+	RateLimit RateLimit
+}
+
+type RateLimit struct {
+	Limit     int64         // X-RateLimit-Limit number of requests allowed in a time period
+	Period    time.Duration // X-RateLimit-Period length of time in seconds for resets (calendar aligned)
+	Remaining int64         // X-RateLimit-Remaining number of allowed requests left in current time period
+	Reset     time.Duration // X-RateLimit-Reset time in seconds until next reset
+}
+
+func (r *RateLimit) LoadFromHeader(h *http.Header) (err error) {
+	var i int64
+
+	// Limit
+	i, err = parseIntFromHeader(h, "X-RateLimit-Limit")
+	if err != nil {
+		return fmt.Errorf("failed to read RateLimit.Limit: %w", ErrHTTP)
+	}
+	r.Limit = i
+
+	// Period
+	i, err = parseIntFromHeader(h, "X-RateLimit-Period")
+	if err != nil {
+		return fmt.Errorf("failed to read RateLimit.Period: %w", ErrHTTP)
+	}
+	r.Period = time.Duration(i) * time.Second
+
+	// Remaining
+	i, err = parseIntFromHeader(h, "X-RateLimit-Remaining")
+	if err != nil {
+		return fmt.Errorf("failed to read RateLimit.Remaining: %w", ErrHTTP)
+	}
+	r.Remaining = i
+
+	// Reset
+	i, err = parseIntFromHeader(h, "X-RateLimit-Reset")
+	if err != nil {
+		return fmt.Errorf("failed to read RateLimit.Reset: %w", ErrHTTP)
+	}
+	r.Reset = time.Duration(i) * time.Second
+
+	return nil
+}
+
+// HTTP implementation details shared between user-facing methods
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+var defaultBaseURL = url.URL{Scheme: "https", Host: "api.datadoghq.com", Path: "/api/v1/"}
+
+func (c *Client) baseURL() *url.URL {
+	if c.BaseURL != nil {
+		return c.BaseURL
+	}
+	return &defaultBaseURL
+}
+
+type errorsResponse struct {
+	Errors []string `json:"errors"`
+}
+
+func (c *Client) doGet(ctx context.Context, u *url.URL, value interface{}, meta *ResponseMetadata) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL().ResolveReference(u).String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	return c.doRequest(req, value, meta)
+}
+
+func (c *Client) doRequest(req *http.Request, value interface{}, meta *ResponseMetadata) (err error) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("DD-API-KEY", c.APIKey)
+	if len(c.AppKey) != 0 {
+		req.Header.Set("DD-APPLICATION-KEY", c.AppKey)
+	}
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if meta != nil {
+		err = meta.RateLimit.LoadFromHeader(&resp.Header)
+		if err != nil {
+			return err
+		}
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+
+	if resp.StatusCode >= 300 {
+		var respError errorsResponse
+		err = decoder.Decode(&respError)
+		if err != nil {
+			return fmt.Errorf("failed to decode error: %w", err)
+		}
+		return fmt.Errorf("%w: %s", ErrHTTP, respError.Errors)
+	}
+
+	err = decoder.Decode(value)
+	if err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}
+
+func parseIntFromHeader(h *http.Header, name string) (seconds int64, err error) {
+	return strconv.ParseInt(h.Get(name), 10, 64)
+}

--- a/datadog/client_test.go
+++ b/datadog/client_test.go
@@ -1,0 +1,355 @@
+package datadog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestClient_Validate(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name      string
+		handler   http.HandlerFunc
+		wantValid bool
+		wantErr   string
+	}{
+		{
+			name: "Valid",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if !correctURL(w, r, "/api/v1/validate") {
+					return
+				}
+				_, _ = fmt.Fprintln(w, `{"valid": true}`)
+			},
+			wantValid: true,
+		},
+		{
+			name: "Invalid",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = fmt.Fprintln(w, `{"valid": false}`)
+			},
+			wantValid: false,
+		},
+		{
+			name: "GarbageResponse",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = fmt.Fprintln(w, `{garbage JSON}`)
+			},
+			wantValid: false,
+			wantErr:   "failed to decode response",
+		},
+		{
+			name: "GoodErrorResponse",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = fmt.Fprintln(w, `{"errors": ["error1", "error2"]}`)
+			},
+			wantValid: false,
+			wantErr:   "datadog HTTP error: [error1 error2]",
+		},
+		{
+			name: "GarbageErrorResponse",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = fmt.Fprintln(w, `{garbage JSON}`)
+			},
+			wantValid: false,
+			wantErr:   "failed to decode error",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			c := testSetup(t, tt.handler)
+
+			gotValid, err := c.Validate(ctx)
+
+			if len(tt.wantErr) == 0 {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+
+			assert.Check(t, cmp.Equal(gotValid, tt.wantValid))
+		})
+	}
+}
+
+func TestClient_QueryMetrics(t *testing.T) {
+	t1 := time.Unix(0, 1430311800000*1e6)
+	t2 := time.Unix(0, 1430312999000*1e6)
+
+	ctx := context.Background()
+	validMetadata := ResponseMetadata{
+		RateLimit: RateLimit{
+			Limit:     600,
+			Period:    time.Hour,
+			Remaining: 597,
+			Reset:     time.Hour - 10*time.Second,
+		},
+	}
+	emptySeries := QueryResponse{Meta: validMetadata}
+
+	tests := []struct {
+		name     string
+		args     QueryParams
+		handler  http.HandlerFunc
+		wantResp QueryResponse
+		wantErr  string
+	}{
+		{
+			name: "Valid",
+			args: QueryParams{From: t1, To: t2, Query: "a valid query"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if !correctURL(w, r, "/api/v1/query?from=1430311800&query=a+valid+query&to=1430312999") {
+					return
+				}
+				addValidRateLimitHeaders(w)
+				_, _ = fmt.Fprintln(w, `
+{
+  "status": "ok",
+  "res_type": "time_series",
+  "series": [
+    {
+      "metric": "system.cpu.idle",
+      "attributes": {},
+      "display_name": "system.cpu.idle",
+      "unit": null,
+      "pointlist": [
+        [
+          1430311800000,
+          98.19375610351562
+        ],
+        [
+          1430312400000,
+          99.85856628417969
+        ]
+      ],
+      "end": 1430312999000,
+      "interval": 600,
+      "start": 1430311800000,
+      "length": 2,
+      "aggr": null,
+      "scope": "host:vagrant-ubuntu-trusty-64",
+      "expression": "system.cpu.idle{host:vagrant-ubuntu-trusty-64}"
+    }
+  ],
+  "from_date": 1430226140000,
+  "group_by": [
+    "host"
+  ],
+  "to_date": 1430312540000,
+  "query": "system.cpu.idle{*}by{host}",
+  "message": ""
+}`)
+			},
+			wantResp: QueryResponse{
+				Series: []Series{
+					{
+						Metric:      "system.cpu.idle",
+						DisplayName: "system.cpu.idle",
+						Points: []DataPoint{
+							{Time: UnixTime{time.Unix(0, 1430311800000*1e6)}, Value: 98.19375610351562},
+							{Time: UnixTime{time.Unix(0, 1430312400000*1e6)}, Value: 99.85856628417969},
+						},
+						Start:      UnixTime{t1},
+						End:        UnixTime{t2},
+						Interval:   600,
+						Length:     2,
+						Scope:      "host:vagrant-ubuntu-trusty-64",
+						Expression: "system.cpu.idle{host:vagrant-ubuntu-trusty-64}"},
+				},
+				Meta: validMetadata,
+			},
+		},
+		{
+			name: "ParseMetadata",
+			args: QueryParams{From: t1, To: t2, Query: "valid"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				addValidRateLimitHeaders(w)
+				_, _ = fmt.Fprintln(w, `{"status": "ok"}`)
+			},
+			wantResp: emptySeries,
+		},
+		{
+			name: "ParseMetadataOnError",
+			args: QueryParams{From: t1, To: t2, Query: "valid"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("X-RateLimit-Limit", "1500")
+				w.Header().Add("X-RateLimit-Period", "3600")
+				w.Header().Add("X-RateLimit-Remaining", "1493")
+				w.Header().Add("X-RateLimit-Reset", "60")
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(&errorsResponse{
+					Errors: []string{"rate limit quote exceeded"},
+				})
+			},
+			wantResp: QueryResponse{
+				Meta: ResponseMetadata{
+					RateLimit: RateLimit{
+						Limit:     1500,
+						Period:    time.Hour,
+						Remaining: 1493,
+						Reset:     time.Minute,
+					},
+				},
+			},
+			wantErr: "rate limit quote exceeded",
+		},
+		{
+			name: "BadRequest",
+			args: QueryParams{From: t1, To: t2, Query: "a bad request"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				addValidRateLimitHeaders(w)
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(&errorsResponse{
+					Errors: []string{"bad request"},
+				})
+			},
+			wantErr:  "datadog HTTP error: [bad request]",
+			wantResp: emptySeries,
+		},
+		{
+			name: "InvalidQuery",
+			args: QueryParams{From: t1, To: t2, Query: "an invalid query"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				addValidRateLimitHeaders(w)
+				_, _ = fmt.Fprintln(w, `{"status": "error", "error": "the reason"}`)
+			},
+			wantErr:  "invalid query: the reason",
+			wantResp: emptySeries,
+		},
+		{
+			name: "GarbageResponse",
+			args: QueryParams{From: t1, To: t2, Query: "something"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				addValidRateLimitHeaders(w)
+				_, _ = fmt.Fprintln(w, `{garbage response}`)
+			},
+			wantErr:  "failed to decode response",
+			wantResp: emptySeries,
+		},
+		{
+			name: "BadTimestamps",
+			args: QueryParams{From: t1, To: t2, Query: "something"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				addValidRateLimitHeaders(w)
+				_, _ = fmt.Fprintln(w, `
+				{
+				  "status": "ok",
+				  "series": [
+				    {
+				      "end": "string instead of numeric"
+				    }
+				  ]
+				}`)
+			},
+			wantErr:  "failed to decode unix time",
+			wantResp: emptySeries,
+		},
+		{
+			name: "BadDataPointTime",
+			args: QueryParams{From: t1, To: t2, Query: "something"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				addValidRateLimitHeaders(w)
+				_, _ = fmt.Fprintln(w, `
+				{
+				  "status": "ok",
+				  "series": [
+				    {
+				      "pointlist": [
+				        [
+				          "should be a numeric",
+				          98.19375610351562
+				        ]
+				      ]
+				    }
+				  ]
+				}`)
+			},
+			wantErr:  "failed to decode data point",
+			wantResp: emptySeries,
+		},
+		{
+			name: "BadDataPointValue",
+			args: QueryParams{From: t1, To: t2, Query: "something"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				addValidRateLimitHeaders(w)
+				_, _ = fmt.Fprintln(w, `
+				{
+				  "status": "ok",
+				  "series": [
+				    {
+				      "pointlist": [
+				        [
+				          1430311800000,
+				          "should be a numeric"
+				        ]
+				      ]
+				    }
+				  ]
+				}`)
+			},
+			wantErr:  "failed to decode data point",
+			wantResp: emptySeries,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			c := testSetup(t, tt.handler)
+
+			gotResp, err := c.Query(ctx, tt.args)
+
+			if len(tt.wantErr) == 0 {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+
+			assert.Check(t, cmp.DeepEqual(gotResp, tt.wantResp))
+		})
+	}
+}
+
+func addValidRateLimitHeaders(w http.ResponseWriter) {
+	w.Header().Add("X-RateLimit-Limit", "600")
+	w.Header().Add("X-RateLimit-Period", "3600")
+	w.Header().Add("X-RateLimit-Remaining", "597")
+	w.Header().Add("X-RateLimit-Reset", "3590")
+}
+
+func correctURL(w http.ResponseWriter, r *http.Request, expectedURL string) bool {
+	if r.URL.String() != expectedURL {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(&errorsResponse{
+			Errors: []string{fmt.Sprintf("%q != %q", r.URL, expectedURL)},
+		})
+		return false
+	}
+	return true
+}
+
+func testSetup(t *testing.T, handler http.HandlerFunc) (client *Client) {
+	ts := httptest.NewServer(handler)
+
+	u, _ := url.Parse(ts.URL)
+	u.Path = "/api/v1/"
+
+	client = &Client{
+		APIKey:  "API Key",
+		AppKey:  "Application Key",
+		BaseURL: u,
+	}
+	t.Cleanup(ts.Close)
+	return client
+}


### PR DESCRIPTION
Have extracted this out of old code from nomad-scaler used to pull metrics from Datadog. This will be used to compare info with Nomad and Docker versions for SLOs around time since latest upgrade.