### PR TITLE
Fix the flaky pool test

### DIFF
--- a/httpserver/httpserver.go
+++ b/httpserver/httpserver.go
@@ -3,6 +3,7 @@ package httpserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -54,9 +55,12 @@ func (s *HTTPServer) Serve(ctx context.Context) error {
 
 	g.Go(func() error {
 		<-ctx.Done()
-		cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		cctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		return s.server.Shutdown(cctx)
+		if err := s.server.Shutdown(cctx); err != nil {
+			return fmt.Errorf("server shutdown failed: %w", err)
+		}
+		return nil
 	})
 
 	g.Go(func() error {


### PR DESCRIPTION
Since we often see handlers setting timeouts of 5s or more on the
ongoing it makes sense to increase the server shutdown timeout, which
increases the chance that we have a clean shutdown.

The server shutdown error is wrapped to make it more clear where the
error is coming from.

This also decreases the chance of seeing a recent test flake where
the server shutdown was occasionally timing out.

Since concurrency is not parallelism we sometimes see less parallelism
in the test runs that causes us to use fewer concurrent connections.

The test has been changed to increase the likelihood of seeing the
expected concurrency, and is also more tolerant to variations.

The interplay between the deferred test context cancellation and the
t.Cleanup is a bit confusing, which happens first? moving the cancel
and wait into the Cleanup felt more explicit (at the marginal cost of
the risk of a rare leaked context)