### PR TITLE
Expose `MetricsProvider` from o11y `Provider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,28 @@ This repository contains a collection of packages designed to aid building
 reliable, observable, zero-downtime services using Go.
 
 ## What is in here?
-- `conf/env` Load application config from environment variables (we are moving away from this).
-- `conf/o11y` Wiring code for the `o11y` package.
-- `conf/secret` Don't store your secrets in a string that can be accidentally logged.
+- `config/env` Load application config from environment variables (we are moving away from this).
+- `config/o11y` Wiring code for the `o11y` package.
+- `config/secret` Don't store your secrets in a string that can be accidentally logged.
   Use a `secret.String` instead.
-- `db` Common patterns using when talking to an RDBMS. Currnetly only supports PostgreSQL.
+- `datadog` A basic Datadog API client for retrieving metrics back from Datadog.
+- `db` Common patterns using when talking to an RDBMS. Only supports PostgreSQL at present.
 - `httpclient` A simple HTTP client that adds observability and resilience to the standard
   Go HTTP client.
 - `httpserver` Starting and stopping the standard Go http server cleanly.
+- `httpserver/ginrouter` A common base for configuring a Gin router instance.
 - `o11y` Observability that is currently backed by Honeycomb. It also supports outputting
   trace data as JSON and plain or colored text output.
+- `o11y/honeycomb` The honeycomb-backed implementation of `o11y`.
+- `o11y/wrappers/o11ygin` `o11y` middleware for the Gin router.
+- `o11y/wrappers/o11ynethttp` `o11y` middleware for the standard Go HTTP server.
 - `system` Manage the startup, running, metrics and shutdown of a Go service.
 - `termination` A handler to aid signal based service termination. (Used internally by
   the `system` package).
 - `testing/compiler` At CircleCI we aim to acceptance test whole compiled binaries. This
   package lets us do that, while capturing test coverage for the binary.
 - `testing/download` Download releases of binaries for using in end to end service testing.
+- `testing/fakemetrics` A fake recording `o11y` metrics implementation.
 - `testing/httprecorder` Record HTTP requests inside an HTTP server, and search them.
 - `testing/kongtest` If you are using [kong](https://github.com/alecthomas/kong) for your
   CLI parsing, this helps in writing golden tests for the CLI definition.

--- a/config/o11y/o11y.go
+++ b/config/o11y/o11y.go
@@ -67,7 +67,9 @@ func setup(ctx context.Context, o Config) (context.Context, func(context.Context
 
 	hostname, _ := os.Hostname()
 
-	if o.Statsd != "" {
+	if o.Statsd == "" {
+		honeyConfig.Metrics = &statsd.NoOpClient{}
+	} else {
 		stats, err := statsd.New(o.Statsd)
 		if err != nil {
 			return nil, nil, err

--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -20,7 +20,9 @@ import (
 	"github.com/circleci/ex/o11y"
 )
 
-type honeycomb struct{}
+type honeycomb struct {
+	metricsProvider o11y.MetricsProvider
+}
 
 type Config struct {
 	Host          string
@@ -115,7 +117,9 @@ func New(conf Config) o11y.Provider {
 
 	beeline.Init(bc)
 
-	return &honeycomb{}
+	return &honeycomb{
+		metricsProvider: conf.Metrics,
+	}
 }
 
 func stripMetrics(fields map[string]interface{}) {
@@ -279,6 +283,10 @@ func (h *honeycomb) Log(ctx context.Context, name string, fields ...o11y.Pair) {
 
 func (h *honeycomb) Close(_ context.Context) {
 	beeline.Close()
+}
+
+func (h *honeycomb) MetricsProvider() o11y.MetricsProvider {
+	return h.metricsProvider
 }
 
 func WrapSpan(s *trace.Span) o11y.Span {

--- a/o11y/o11y.go
+++ b/o11y/o11y.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/rollbar/rollbar-go"
 )
 
@@ -51,6 +52,9 @@ type Provider interface {
 	Log(ctx context.Context, name string, fields ...Pair)
 
 	Close(ctx context.Context)
+
+	// MetricsProvider grants lower control over the metrics that o11y sends, allowing skipping spans.
+	MetricsProvider() MetricsProvider
 }
 
 type Span interface {
@@ -279,6 +283,10 @@ func (c *noopProvider) AddFieldToTrace(ctx context.Context, key string, val inte
 func (c *noopProvider) Close(ctx context.Context) {}
 
 func (c *noopProvider) Log(ctx context.Context, name string, fields ...Pair) {}
+
+func (c *noopProvider) MetricsProvider() MetricsProvider {
+	return &statsd.NoOpClient{}
+}
 
 type noopSpan struct{}
 

--- a/testing/fakemetrics/fakemetrics.go
+++ b/testing/fakemetrics/fakemetrics.go
@@ -1,0 +1,67 @@
+package fakemetrics
+
+import (
+	"fmt"
+	"sync"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type MetricCall struct {
+	Metric   string
+	Name     string
+	Value    float64
+	ValueInt int64
+	Tags     []string
+	Rate     float64
+}
+
+var CMPMetrics = gocmp.Options{
+	cmpopts.EquateApprox(0, 4),
+	cmpopts.SortSlices(func(x, y MetricCall) bool {
+		const format = "%s|%s|%s"
+		return fmt.Sprintf(format, x.Metric, x.Name, x.Tags) <
+			fmt.Sprintf(format, y.Metric, y.Name, y.Tags)
+	}),
+}
+
+type Provider struct {
+	mu sync.RWMutex
+
+	// mutable state
+	calls []MetricCall
+}
+
+func (f *Provider) Calls() []MetricCall {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	calls := make([]MetricCall, len(f.calls))
+	copy(calls, f.calls)
+	return calls
+}
+
+func (f *Provider) TimeInMilliseconds(name string, value float64, tags []string, rate float64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.calls = append(f.calls, MetricCall{Metric: "timer", Name: name, Value: value, Tags: tags, Rate: rate})
+	return nil
+}
+
+func (f *Provider) Gauge(name string, value float64, tags []string, rate float64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.calls = append(f.calls, MetricCall{Metric: "gauge", Name: name, Value: value, Tags: tags, Rate: rate})
+	return nil
+}
+
+func (f *Provider) Count(name string, value int64, tags []string, rate float64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.calls = append(f.calls, MetricCall{Metric: "count", Name: name, ValueInt: value, Tags: tags, Rate: rate})
+	return nil
+}


### PR DESCRIPTION
- Also use the direct metrics interface for the system metrics, instead of creating spans.