### PR TITLE
Fixed compiler clobbering GOPATH in linux

### DIFF
--- a/testing/compiler/compiler.go
+++ b/testing/compiler/compiler.go
@@ -61,7 +61,7 @@ func goPath() string {
 	if goroot == "" {
 		return "go"
 	}
-	return filepath.Join(filepath.Dir(goroot), "bin", "go")
+	return filepath.Join(goroot, "bin", "go")
 }
 
 func binaryPath(name, tempDir string) string {


### PR DESCRIPTION
`Compiler.Compile()` was calling `filepath.Dir()` on the GOROOT which drops the last item in a path string and so was creating an invalid path on linux systems. I believe this bug wasn't being caught on mac systems due to a quirk in how mac installs Go (I think the GOROOT points to a symlink folder nested in the actual go directory), but the change should still work on mac regardless.