### PR TITLE
Add No-op metrics provider to `testcontext.Background()`

### DIFF
--- a/testing/testcontext/context.go
+++ b/testing/testcontext/context.go
@@ -3,6 +3,8 @@ package testcontext
 import (
 	"context"
 
+	"github.com/DataDog/datadog-go/statsd"
+
 	"github.com/circleci/ex/o11y"
 	"github.com/circleci/ex/o11y/honeycomb"
 )
@@ -17,5 +19,8 @@ func Background() context.Context {
 }
 
 func newContext() context.Context {
-	return o11y.WithProvider(context.Background(), honeycomb.New(honeycomb.Config{Format: "color"}))
+	return o11y.WithProvider(context.Background(), honeycomb.New(honeycomb.Config{
+		Format:  "color",
+		Metrics: &statsd.NoOpClient{},
+	}))
 }

--- a/testing/testcontext/context_test.go
+++ b/testing/testcontext/context_test.go
@@ -1,0 +1,17 @@
+package testcontext
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/circleci/ex/o11y"
+)
+
+func TestBackground_MetricsProvider(t *testing.T) {
+	ctx := Background()
+	metrics := o11y.FromContext(ctx).MetricsProvider()
+
+	err := metrics.Gauge("gauge", 1, nil, 1)
+	assert.Assert(t, err)
+}


### PR DESCRIPTION
- This means that code can send metrics under test without needing `nil` checks.