### PR TITLE
Retry our transactions on bad connections

### DIFF
--- a/db/transactions.go
+++ b/db/transactions.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 
@@ -22,6 +23,24 @@ func NewTxManager(db *sqlx.DB) *TxManager {
 
 func (s *TxManager) WithTransaction(ctx context.Context, f func(context.Context, Querier) error) (err error) {
 	ctx, span := o11y.StartSpan(ctx, "tx-manager: with-transaction")
+	defer o11y.End(span, &err)
+
+	// Retry this transaction 3 times
+	for i := 0; i < 3; i++ {
+		err = s.WithOneTransaction(ctx, f)
+		if !errors.Is(err, driver.ErrBadConn) {
+			break
+		}
+		o11y.AddField(ctx, "bad_con", i)
+		o11y.AddField(ctx, "warning", err)
+	}
+
+	// Note that the above defer can reassign err
+	return err
+}
+
+func (s *TxManager) WithOneTransaction(ctx context.Context, f func(context.Context, Querier) error) (err error) {
+	ctx, span := o11y.StartSpan(ctx, "tx-manager: with-one-transaction")
 	defer o11y.End(span, &err)
 
 	tx, err := s.DB.BeginTxx(ctx, nil)


### PR DESCRIPTION
Since transactions need to use a single connection and can execute
multiple statements they all have to use the same connection.

If that connection goes bad - there is no point retrying the individual
statements - since they still need the transaction which is now associated
with a bad connection.

Begin and End transaction are application side calls so there is no stdlib
retry mechanism like there is on direct DB statements.

The ex library is robust wrt rollbacks in a failed transaction, so we can
be reassured that retrying a transaction is safe.

This change adds a minimal number of retries (similar to the stdlib count)
in the face of a bad connection.

Exactly what causes a bad connection is unclear. Some sources suggest it can
be a side effect of the server timing out a transaction. We do see a relatively
consistent 250ms statement time when we get a bad connection error, but who
know whether that is in the tcp layer or due to a server side statement timeout