### PR TITLE
Honour 429's by not allowing the client to make calls for 10s

### DIFF
--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -456,7 +456,7 @@ func TestClient_ConnectionPool(t *testing.T) {
 	})
 
 	t.Run("keep-alive", func(t *testing.T) {
-		// Fire 100 requests at the server
+		// Fire a few requests at the server
 		client := New(Config{
 			Name:    "keep-alive",
 			BaseURL: "http://" + srv.Addr(),
@@ -521,5 +521,147 @@ func TestClient_ConnectionPool(t *testing.T) {
 		// but we would not expect a huge number of dropped connections
 		assert.Check(t, totalNewConnectionsMade < maxConnections+5,
 			"made mre connections (%d) than expected (%d)", totalNewConnectionsMade, maxConnections+5)
+	})
+}
+
+func TestClient_ExplicitBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(testcontext.Background())
+
+	var mu sync.RWMutex
+	send429 := false
+	handlerCount := 0
+	now := time.Now()
+	nowFn := func() time.Time {
+		mu.RLock()
+		defer mu.RUnlock()
+		return now
+	}
+	// start our server with a handler that writes a response and in a certain range of
+	// requests returns 429's
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		doSend := send429
+		handlerCount++
+		mu.Unlock()
+		if doSend {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = io.WriteString(w, `{"hello": "world!"} ...`)
+		// to help the client have the full number of concurrent requests in flight
+		time.Sleep(2 * time.Millisecond)
+	})
+
+	srv, err := httpserver.New(ctx, "test server", "localhost:0", h)
+	assert.Assert(t, err)
+
+	g, ctx := errgroup.WithContext(ctx)
+	t.Cleanup(func() {
+		cancel()
+		assert.Check(t, g.Wait())
+	})
+	g.Go(func() error {
+		return srv.Serve(ctx)
+	})
+
+	t.Run("backoff", func(t *testing.T) {
+		client := New(Config{
+			Name:    "keep-alive",
+			BaseURL: "http://" + srv.Addr(),
+			Timeout: time.Second,
+		})
+		client.now = nowFn
+		req := NewRequest("POST", "/", time.Second)
+
+		// Making concurrent calls in this test to increase the chance of
+		// flushing out any race in the client
+		const numReq = 50
+		var wg sync.WaitGroup
+		wg.Add(numReq)
+		for n := 0; n < numReq; n++ {
+			go func() {
+				err := client.Call(context.Background(), req)
+				assert.NilError(t, err)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		// At some random point start sending 429's (and explicitly stop setting once we have)
+		ctx429, cancel429 := context.WithCancel(ctx)
+		go func() {
+			for {
+				if ctx429.Err() != nil {
+					return
+				}
+				// start sending 429's
+				mu.Lock()
+				if handlerCount > numReq+5 {
+					send429 = true
+					cancel429()
+				}
+				mu.Unlock()
+				time.Sleep(time.Microsecond * 10)
+			}
+		}()
+
+		// hopefully during these concurrent calls we will see the 429 and the explicit backoff
+		// It is not critical that we do, it is just statistically likely, and in that case
+		// we can be confident that we would see if the client was racy.
+		wg.Add(numReq)
+		for n := 0; n < numReq; n++ {
+			go func() {
+				// these calls may see a mix of nil error, explicit backoff
+				// and 429's most likely all 429's, so no point testing the error
+				_ = client.Call(context.Background(), req)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		// make sure we stop sending 429's after the backoff time has elapsed
+		// wait until we are sure the 429 setting loop above is complete
+		<-ctx429.Done()
+		send429 = false
+
+		// confirm the server may have seen all or none of the calls whilst the 429 was being set
+		assert.Check(t, handlerCount > numReq && handlerCount <= numReq*2, handlerCount)
+
+		// there is a v slim chance this call is the first one to see the 429
+		_ = client.Call(context.Background(), req)
+
+		// but this one will definitely be an explicit backoff
+		curHandlerCount := handlerCount
+		err = client.Call(context.Background(), req)
+		assert.ErrorContains(t, err, "explicit backoff")
+		// and will not have called the server
+		assert.Check(t, cmp.Equal(curHandlerCount, handlerCount))
+
+		// during some concurrent calls set the time to have elapsed past the 10s last 429 time
+		// to close the circuit - these calls may not see the close, or they may all see it
+		// or something in between, so there is not much we can assert.
+		wg.Add(numReq)
+		for n := 0; n < numReq; n++ {
+			// at some random point boost the time to close the circuit
+			if n == 10 {
+				go func() {
+					mu.Lock()
+					now = now.Add(time.Second * 20)
+					mu.Unlock()
+				}()
+			}
+			go func() {
+				err := client.Call(context.Background(), req)
+				if err != nil {
+					assert.ErrorContains(t, err, "explicit backoff")
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		// this call will definitely nt see the explicit backoff
+		err = client.Call(context.Background(), req)
+		assert.NilError(t, err)
 	})
 }


### PR DESCRIPTION
Hard coded 10s backoff if a 429 is seen.

A future enhancement would be to honour any `Retry-After` header.

This will allow our clients to help unload servers that are struggling (429-ing) in all but the coldest paths (where clients call less than once per 10 seconds)

The test for this looks relatively complex, but it is designed to increase the chances of concurrently mutating the internal 429 handling. 

As we add more services that can respond 429 for their own protection, we may need to differentiate per client (or maybe per call) those that may ignore the backoff (or push it into their app logic - for instance queue the call to retry later) because it is in a critical path, and those that can gracefully degrade their behaviour and discard the call.