### PR TITLE
Make Redis DB configurable

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -16,6 +16,7 @@ type Options struct {
 	Port     int
 	User     string
 	Password secret.String
+	DB       int
 
 	// Optional
 	TLS    bool
@@ -29,6 +30,7 @@ func New(o Options) *redis.Client {
 		Addr:     net.JoinHostPort(o.Host, strconv.FormatInt(int64(o.Port), 10)),
 		Username: o.User,
 		Password: o.Password.Value(),
+		DB:       o.DB,
 	}
 	if o.TLS {
 		var rootCAs *x509.CertPool

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,9 +1,12 @@
 package redis
 
 import (
+	"errors"
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/go-redis/redis/v8"
 
 	"github.com/circleci/ex/testing/testcontext"
 )
@@ -11,11 +14,37 @@ import (
 func TestNew(t *testing.T) {
 	ctx := testcontext.Background()
 
-	client := New(Options{
+	client1 := New(Options{
 		Host: "localhost",
 		Port: 6379,
+		DB:   1,
+	})
+	defer client1.Close()
+
+	t.Run("simple connection", func(t *testing.T) {
+		err := client1.Ping(ctx).Err()
+		assert.NilError(t, err)
 	})
 
-	err := client.Ping(ctx).Err()
-	assert.Check(t, err)
+	t.Run("connecting to different databases works", func(t *testing.T) {
+		t.Run("set key in DB 1", func(t *testing.T) {
+			err := client1.Set(ctx, "foo", "bar", 0).Err()
+			assert.NilError(t, err)
+			b1, err := client1.Get(ctx, "foo").Bytes()
+			assert.NilError(t, err)
+			assert.Equal(t, "bar", string(b1))
+		})
+
+		t.Run("check key is not found in DB 2", func(t *testing.T) {
+			client2 := New(Options{
+				Host: "localhost",
+				Port: 6379,
+				DB:   2,
+			})
+			defer client2.Close()
+
+			err := client2.Get(ctx, "foo").Err()
+			assert.Check(t, errors.Is(err, redis.Nil))
+		})
+	})
 }


### PR DESCRIPTION
This adds the ability to choose which Redis DB on the instance to use when creating the client.