### PR TITLE
`o11y`: Add `none` output mode

### DIFF
--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -74,6 +74,8 @@ func (c *Config) sender() transmission.Sender {
 		s.Senders = append(s.Senders, &TextSender{w: writer})
 	case "colour", "color":
 		s.Senders = append(s.Senders, &TextSender{w: writer, colour: true})
+	case "none":
+		break
 	case "json":
 		fallthrough
 	default:


### PR DESCRIPTION
- It's wasteful to send spans to both stdout and our trace provider, if we only look at the trace provider.