### PR TITLE
`redisfixture`: Use an enforced bigger hash space

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           POSTGRES_PASSWORD: password
           POSTGRES_DB: dbname
       - image: circleci/redis:5.0.6-alpine
-        command: [ "--databases", "2048" ]
+        command: [ "--databases", "1000000" ]
       - image: rabbitmq:3.8-management-alpine
     working_directory: ~/project/<<parameters.submodule>>
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   redis:
     image: circleci/redis:5.0.6-alpine
-    command: ["--databases", "2048"]
+    command: ["--databases", "1000000"]
     ports:
       - '127.0.0.1:6379:6379'
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/michaelklishin/rabbit-hole/v2 v2.11.0
 	github.com/rollbar/rollbar-go v1.4.2
 	github.com/streadway/amqp v1.0.1-0.20200716223359-e6b33f460591
-	golang.org/x/mod v0.5.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gotest.tools/v3 v3.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,6 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
-golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/testing/redisfixture/redisfixture_test.go
+++ b/testing/redisfixture/redisfixture_test.go
@@ -4,20 +4,18 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 
 	"github.com/circleci/ex/testing/testcontext"
 )
 
-func Test_relativePackageName(t *testing.T) {
-	assert.Check(t, cmp.Equal(relativePackageName(1), "/testing/redisfixture"))
-}
-
-func Test_packageName(t *testing.T) {
-	assert.Check(t, cmp.Equal(packageName(0), "github.com/circleci/ex/testing/redisfixture"))
-}
-
 func TestSetup(t *testing.T) {
+	ctx := testcontext.Background()
+	fix := Setup(ctx, t)
+	assert.Check(t, fix.Ping(ctx).Err())
+	assert.Check(t, fix.DB > 0)
+}
+
+func TestSetupAgain(t *testing.T) {
 	ctx := testcontext.Background()
 	fix := Setup(ctx, t)
 	assert.Check(t, fix.Ping(ctx).Err())


### PR DESCRIPTION
- The previous strategy of deriving the package name wasn't always working.
- If you put the call to redisfixture in a shared test helper, then the same package name was always dervied.
- Now we just enforce a really big space for the DBs (1 million), so there's much less chance of collision.