### PR TITLE
Retry and o11y improvements.

### DIFF
--- a/httpclient/doc.go
+++ b/httpclient/doc.go
@@ -1,5 +1,0 @@
-/*
-Package httpclient contains a simple HTTP client that adds observability and resilience to the standard
-Go HTTP client.
-*/
-package httpclient


### PR DESCRIPTION
This grew into a few separate cleanups. Whilst fairly self contained I am Happy to split into separate PR's for the reviewers pleasure.

During the retry loop any of the retryable http errors are treated as
warnings. Only once the retrying is over do we then treat the
HTTPError as an error, because then it is fair that the client
errored. Whilst we don't have the higher level call span anymore (for
cost savings) but this is actually a reasonably sensible default
since it is up to the client code to decide how it manifests the
HTTPError.

During recent investigations it was clear the default .5s
before retrying the next request resulted in too few retries.
The initial retry period is reduced to 50ms resulting in 5-6
retries in our more common 3s total timeout calls, from a
previous 2-3.

maxInterval in the backoff is dropped since it was never hit.
Rather the overall backoff timeout was always the limiting factor.

Various span field additions are moved into helpers, for improved
code clarity.

Removes the recently added doc.go from the httpclient package since
it duplicated the existing (slightly more detailed) package docstring.

Also added the possibly breaking change removing the deprecated method
but its about time peeps updated (I think they all have)