### PR TITLE
Allow disabling statsd telemetry

### DIFF
--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -21,7 +21,7 @@ import (
 )
 
 type honeycomb struct {
-	metricsProvider o11y.MetricsProvider
+	metricsProvider o11y.ClosableMetricsProvider
 }
 
 type Config struct {
@@ -34,7 +34,7 @@ type Config struct {
 	SampleTraces  bool
 	SampleKeyFunc func(map[string]interface{}) string
 	Writer        io.Writer
-	Metrics       o11y.MetricsProvider
+	Metrics       o11y.ClosableMetricsProvider
 
 	Debug bool
 }
@@ -290,6 +290,9 @@ func (h *honeycomb) Log(ctx context.Context, name string, fields ...o11y.Pair) {
 
 func (h *honeycomb) Close(_ context.Context) {
 	beeline.Close()
+	if h.metricsProvider != nil {
+		_ = h.metricsProvider.Close()
+	}
 }
 
 func (h *honeycomb) MetricsProvider() o11y.MetricsProvider {

--- a/o11y/o11y.go
+++ b/o11y/o11y.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"runtime/debug"
@@ -148,6 +149,11 @@ type MetricsProvider interface {
 	Gauge(name string, value float64, tags []string, rate float64) error
 	// Count sends an individual value in time.
 	Count(name string, value int64, tags []string, rate float64) error
+}
+
+type ClosableMetricsProvider interface {
+	MetricsProvider
+	io.Closer
 }
 
 type providerKey struct{}

--- a/testing/fakemetrics/fakemetrics.go
+++ b/testing/fakemetrics/fakemetrics.go
@@ -65,3 +65,7 @@ func (f *Provider) Count(name string, value int64, tags []string, rate float64) 
 	f.calls = append(f.calls, MetricCall{Metric: "count", Name: name, ValueInt: value, Tags: tags, Rate: rate})
 	return nil
 }
+
+func (f *Provider) Close() error {
+	return nil
+}

--- a/testing/fakestatsd/fakestatsd.go
+++ b/testing/fakestatsd/fakestatsd.go
@@ -1,0 +1,112 @@
+package fakestatsd
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+type FakeStatsd struct {
+	connection *net.UDPConn
+
+	// mutable state
+	mu      sync.RWMutex
+	metrics []Metric
+}
+
+func New(t testing.TB) *FakeStatsd {
+	t.Helper()
+
+	addr, err := net.ResolveUDPAddr("udp", "localhost:0")
+	assert.Assert(t, err)
+
+	conn, err := net.ListenUDP("udp", addr)
+	assert.Assert(t, err)
+
+	s := &FakeStatsd{
+		connection: conn,
+	}
+	go s.listen()
+	t.Cleanup(s.close)
+
+	return s
+}
+
+func (s *FakeStatsd) Addr() string {
+	return s.connection.LocalAddr().String()
+}
+
+type Metric struct {
+	Name  string
+	Value string
+	Tags  string
+}
+
+func (s *FakeStatsd) Metrics() []Metric {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	metrics := make([]Metric, len(s.metrics))
+	copy(metrics, s.metrics)
+	return metrics
+}
+
+func (s *FakeStatsd) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.metrics = nil
+}
+
+func (s *FakeStatsd) recordMetric(m Metric) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.metrics = append(s.metrics, m)
+}
+
+func (s *FakeStatsd) listen() {
+	buffer := make([]byte, 10000)
+
+	for {
+		numBytes, err := s.connection.Read(buffer)
+		if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
+			break
+		}
+
+		rawMetrics := buffer[0:numBytes]
+		splitMetrics := bytes.Split(rawMetrics, []byte("\n"))
+
+		for _, rawMetric := range splitMetrics {
+			rawMetric = bytes.TrimSpace(rawMetric)
+			if len(rawMetric) == 0 {
+				continue
+			}
+			metric := parse(string(rawMetric))
+			s.recordMetric(metric)
+		}
+	}
+}
+
+func (s *FakeStatsd) close() {
+	_ = s.connection.Close()
+}
+
+func parse(raw string) Metric {
+	metricNameAndRest := strings.SplitN(raw, ":", 2)
+	name := metricNameAndRest[0]
+	valueAndTags := strings.SplitN(metricNameAndRest[1], "#", 2)
+	value := valueAndTags[0]
+	tags := ""
+
+	if len(valueAndTags) > 1 {
+		tags = valueAndTags[1]
+		tags = strings.Replace(tags, ",", " ", -1)
+	}
+
+	return Metric{Name: name, Value: value, Tags: tags}
+}


### PR DESCRIPTION
- Avoid the associated costs of Datadog telemetry for agents where we're not interested in it.
- Add a recording statsd server for testing the statsd integation.
- Also close the statsd client on o11y close.