### PR TITLE
Include more pq error detail

### DIFF
--- a/db/error.go
+++ b/db/error.go
@@ -47,7 +47,6 @@ func mapExecErrors(err error, res sql.Result) error {
 // mapError maps a few pq errors to errors defined in this package, some wrapping the original
 // error. If a mapping was made the returned bool will be true, if not the original error is returned and
 // the bool will be false.
-// nolint: golint - error, bool is fine for error mapping funcs
 func mapError(err error) (bool, error) {
 	if ok, e := mapBadCon(err); ok {
 		return true, e
@@ -56,13 +55,13 @@ func mapError(err error) (bool, error) {
 	if errors.As(err, &e) {
 		switch e.Code {
 		case pgForeignKeyConstraintErrorCode:
-			return true, ErrConstrained
+			return true, fmt.Errorf("%w: %s - %s", ErrConstrained, e.Message, e.Detail)
 		case pgExceptionRaised:
-			return true, fmt.Errorf("%w: %s", ErrException, e.Message)
+			return true, fmt.Errorf("%w: %s - %s", ErrException, e.Message, e.Detail)
 		case pgStatementCanceled:
-			return true, fmt.Errorf("%w: %s", ErrCanceled, e.Message)
+			return true, fmt.Errorf("%w: %s - %s", ErrCanceled, e.Message, e.Detail)
 		case pgUniqueViolationErrorCode:
-			return true, fmt.Errorf("%w: %s", ErrNop, e.Message)
+			return true, fmt.Errorf("%w: %s - %s", ErrNop, e.Message, e.Detail)
 		}
 	}
 	return false, err


### PR DESCRIPTION
Changing errors has the potential to be a breaking change, however this only changes the err.Error() value.

That can be a breaking change - though it should not be, (folk *should* not test the string (though with bad API's they may have to)). 

Tests are likely the most common way the Error() is tested, though here we are only adding to the message, so hopefully there are not too many tests checking the whole Error() string in packages that use `ex\db` 
