### PR TITLE
Use TestingTB interface instead of testing.TB

### DIFF
--- a/testing/dbfixture/dbfixture.go
+++ b/testing/dbfixture/dbfixture.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -19,6 +18,7 @@ import (
 	"github.com/circleci/ex/config/secret"
 	"github.com/circleci/ex/db"
 	"github.com/circleci/ex/o11y"
+	"github.com/circleci/ex/testing/types"
 )
 
 var globalFixture = &SharedFixture{}
@@ -36,12 +36,12 @@ func (s *SharedFixture) Manager() *Manager {
 
 // SetupSystem prepares the running system for use
 // callers should not rely on the fact this currently uses a package global
-func SetupSystem(t testing.TB, con Connection) *SharedFixture {
+func SetupSystem(t types.TestingTB, con Connection) *SharedFixture {
 	return setupSystem(t, con)
 }
 
 // setupSystem prepares the running system for use
-func setupSystem(t testing.TB, con Connection) *SharedFixture {
+func setupSystem(t types.TestingTB, con Connection) *SharedFixture {
 	globalFixture.once.Do(func() {
 		var err error
 		globalFixture.m, err = newManager(con)
@@ -65,7 +65,7 @@ type Connection struct {
 	Password secret.String
 }
 
-func SetupDB(ctx context.Context, t testing.TB, schema string, con Connection) (db *Fixture) {
+func SetupDB(ctx context.Context, t types.TestingTB, schema string, con Connection) (db *Fixture) {
 	t.Helper()
 	shared := SetupSystem(t, con)
 	db, err := shared.Manager().NewDB(ctx, con, t.Name(), schema)

--- a/testing/fakestatsd/fakestatsd.go
+++ b/testing/fakestatsd/fakestatsd.go
@@ -5,9 +5,10 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/circleci/ex/testing/types"
 )
 
 type FakeStatsd struct {
@@ -18,7 +19,7 @@ type FakeStatsd struct {
 	metrics []Metric
 }
 
-func New(t testing.TB) *FakeStatsd {
+func New(t types.TestingTB) *FakeStatsd {
 	t.Helper()
 
 	addr, err := net.ResolveUDPAddr("udp", "localhost:0")

--- a/testing/rabbitfixture/rabbitfixture.go
+++ b/testing/rabbitfixture/rabbitfixture.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -17,9 +16,10 @@ import (
 	"github.com/circleci/ex/config/secret"
 	"github.com/circleci/ex/o11y"
 	"github.com/circleci/ex/testing/rabbitfixture/internal/rabbit"
+	"github.com/circleci/ex/testing/types"
 )
 
-func Dialer(ctx context.Context, t testing.TB, u string) *amqpextra.Dialer {
+func Dialer(ctx context.Context, t types.TestingTB, u string) *amqpextra.Dialer {
 	dialer, err := amqpextra.NewDialer(
 		amqpextra.WithContext(ctx),
 		amqpextra.WithURL(u),
@@ -32,7 +32,7 @@ func Dialer(ctx context.Context, t testing.TB, u string) *amqpextra.Dialer {
 	return dialer
 }
 
-func New(ctx context.Context, t testing.TB) (rawurl string) {
+func New(ctx context.Context, t types.TestingTB) (rawurl string) {
 	t.Helper()
 	return NewWithConnection(ctx, t, Connection{})
 }
@@ -43,7 +43,7 @@ type Connection struct {
 	Password secret.String
 }
 
-func NewWithConnection(ctx context.Context, t testing.TB, con Connection) (rawurl string) {
+func NewWithConnection(ctx context.Context, t types.TestingTB, con Connection) (rawurl string) {
 	t.Helper()
 	ctx, span := o11y.StartSpan(ctx, "rabbitfixure: vhost")
 	defer span.End()

--- a/testing/redisfixture/redisfixture.go
+++ b/testing/redisfixture/redisfixture.go
@@ -5,13 +5,13 @@ import (
 	"hash/fnv"
 	"strconv"
 	"sync"
-	"testing"
 
 	"github.com/go-redis/redis/v8"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 
 	"github.com/circleci/ex/o11y"
+	"github.com/circleci/ex/testing/types"
 )
 
 type Fixture struct {
@@ -26,7 +26,7 @@ var (
 	databaseCount = uint32(0)
 )
 
-func Setup(ctx context.Context, t testing.TB) *Fixture {
+func Setup(ctx context.Context, t types.TestingTB) *Fixture {
 	ctx, span := o11y.StartSpan(ctx, "redisfixture: setup")
 	defer span.End()
 
@@ -65,7 +65,7 @@ func Setup(ctx context.Context, t testing.TB) *Fixture {
 	}
 }
 
-func checkRedisConnection(ctx context.Context, t testing.TB, client *redis.Client) {
+func checkRedisConnection(ctx context.Context, t types.TestingTB, client *redis.Client) {
 	err := client.Ping(ctx).Err()
 	switch {
 	case err != nil && err.Error() == "ERR DB index is out of range":
@@ -75,7 +75,7 @@ func checkRedisConnection(ctx context.Context, t testing.TB, client *redis.Clien
 	}
 }
 
-func readDatabasesCount(ctx context.Context, t testing.TB) {
+func readDatabasesCount(ctx context.Context, t types.TestingTB) {
 	t.Helper()
 
 	setupClient := redis.NewClient(&redis.Options{

--- a/testing/types/doc.go
+++ b/testing/types/doc.go
@@ -1,0 +1,4 @@
+/*
+Package types contains various interfaces for writing tests.
+*/
+package types

--- a/testing/types/types.go
+++ b/testing/types/types.go
@@ -1,0 +1,17 @@
+package types
+
+// TestingTB is an interface that describes the implementation of the testing object.
+// Using an interface that describes testing.TB instead of the actual implementation
+// allows us to use the utils with other runners (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
+type TestingTB interface {
+	Cleanup(func())
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...interface{})
+	Helper()
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+	Name() string
+	Skip(args ...interface{})
+}


### PR DESCRIPTION
Use `TestingTB` interface instead of `testing.TB`

`TestingTB` allows for non `*testing.T` instances to be passed in. This allows the testing utils to work with other test runners like Ginkgo.