### PR TITLE
recontext lib for deriving contexts that outlive parents

### DIFF
--- a/recontext/context.go
+++ b/recontext/context.go
@@ -1,0 +1,30 @@
+// Package recontext provides means of obtaining a derived context which ignores parent's deadline, timeout, and
+// cancellation.
+package recontext
+
+import (
+	"context"
+	"time"
+)
+
+// Context that wraps another and suppresses its deadline or cancellation.
+// Suppression works by redefining error and timeout/deadline methods for this context impl, however
+// the struct itself is never handed out, and instead is wrapped in a standard context from the context
+// library, which adds a separate deadline/timeout to prevent stuck contexts.
+type valueOnlyContext struct{ context.Context }
+
+// WithNewDeadline returns a derived context that will ignore cancellation, deadline, and timeout of the parent context.
+// In order to avoid stuck contexts, new deadline is mandatory.
+func WithNewDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(&valueOnlyContext{parent}, deadline)
+}
+
+// WithNewTimeout returns a derived context that will ignore cancellation, deadline, and timeout of the parent context.
+// In order to avoid stuck contexts, new timeout is mandatory.
+func WithNewTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(&valueOnlyContext{parent}, timeout)
+}
+
+func (valueOnlyContext) Deadline() (deadline time.Time, ok bool) { return }
+func (valueOnlyContext) Done() <-chan struct{}                   { return nil }
+func (valueOnlyContext) Err() error                              { return nil }

--- a/recontext/context_test.go
+++ b/recontext/context_test.go
@@ -1,0 +1,84 @@
+package recontext
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestContextValues(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "testkey", "testvalue")
+	derivedCtx, cancel := WithNewDeadline(ctx, time.Now())
+	defer cancel()
+	assert.Check(t, cmp.Equal(derivedCtx.Value("testkey"), "testvalue"))
+}
+
+func TestNewContextExpiration(t *testing.T) {
+	oldDeadline := time.Now().Add(-time.Minute)
+	oldCtx, cancel := context.WithDeadline(context.Background(), oldDeadline)
+	defer cancel()
+
+	t.Run("deadline", func(t *testing.T) {
+		newDeadline := time.Now().Add(time.Minute)
+		derivedCtx, _ := WithNewDeadline(oldCtx, newDeadline)
+
+		actualDeadline, _ := derivedCtx.Deadline()
+		assert.Check(t, cmp.Equal(actualDeadline, newDeadline))
+		assert.Check(t, actualDeadline != oldDeadline)
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		now := time.Now()
+		timeout := time.Second * 100
+		derivedCtx, _ := WithNewTimeout(oldCtx, timeout)
+
+		actualDeadline, _ := derivedCtx.Deadline()
+		expectedDeadline := now.Add(timeout)
+		delta := actualDeadline.Sub(expectedDeadline)
+		assert.Check(t, delta < time.Millisecond,
+			fmt.Sprintf("real deadline: %v must be within 1ms since the expected deadline: %v, is %v",
+				actualDeadline, expectedDeadline, delta))
+		assert.Check(t, actualDeadline != oldDeadline)
+	})
+}
+
+func TestNewContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	derivedCtx, derivedCancel := WithNewTimeout(ctx, time.Second*10)
+
+	t.Run("both contexts active", func(t *testing.T) {
+		assert.Check(t, !isDone(ctx))
+		assert.Check(t, !isDone(derivedCtx))
+
+		assert.Check(t, cmp.Nil(ctx.Err()))
+		assert.Check(t, cmp.Nil(derivedCtx.Err()))
+	})
+
+	cancel()
+
+	t.Run("original context done, derived active", func(t *testing.T) {
+		assert.Check(t, isDone(ctx))
+		assert.Check(t, !isDone(derivedCtx))
+
+		assert.Check(t, cmp.ErrorContains(ctx.Err(), "context canceled"), "original context cancelled")
+		assert.Check(t, cmp.Nil(derivedCtx.Err()), "derived context not cancelled")
+	})
+
+	derivedCancel()
+	assert.Check(t, cmp.Error(derivedCtx.Err(), "context canceled"), "derived context cancelled")
+}
+
+func isDone(ctx context.Context) bool {
+	done := false
+	select {
+	case <-ctx.Done():
+		done = true
+	default:
+		done = false
+	}
+	return done
+}


### PR DESCRIPTION
Enforces a new mandatory timeout/deadline to prevent stuck contexts.

Supersedes https://github.com/circleci/ex/pull/147