### PR TITLE
Be more explicit about port detection failure.

### DIFF
--- a/testing/runner/runner_test.go
+++ b/testing/runner/runner_test.go
@@ -19,80 +19,107 @@ func TestRunner(t *testing.T) {
 	c := compiler.New()
 	t.Cleanup(c.Cleanup)
 
-	t.Run("Compile test service", func(t *testing.T) {
-		var err error
-		binary, err = c.Compile(ctx, "my-binary", ".", "./internal/testservice")
-		assert.Assert(t, err)
-	})
+	var err error
+	binary, err = c.Compile(ctx, "my-binary", ".", "./internal/testservice")
+	assert.Assert(t, err)
 
-	r := NewWithDynamicEnv(
-		[]string{
-			"a=a",
-			"b=b",
-			"c=c",
-		},
-		func() []string {
-			return []string{
-				"d=d",
-			}
-		},
-	)
-	t.Cleanup(func() {
-		assert.Check(t, r.Stop())
-	})
-
-	var res *Result
-	t.Run("Start service", func(t *testing.T) {
-		var err error
-		res, err = r.Run("the-server-name", binary, "e=e")
-		assert.Assert(t, err)
-	})
-
-	t.Run("Check the right environment was set", func(t *testing.T) {
-		c := httpclient.New(httpclient.Config{
-			Name:       "the-client-name",
-			BaseURL:    res.APIAddr(),
-			AcceptType: httpclient.JSON,
-			Timeout:    2 * time.Second,
+	t.Run("api_and_admin", func(t *testing.T) {
+		r := NewWithDynamicEnv(
+			[]string{
+				"a=a",
+				"b=b",
+				"c=c",
+			},
+			func() []string {
+				return []string{
+					"d=d",
+				}
+			},
+		)
+		t.Cleanup(func() {
+			assert.Check(t, r.Stop())
 		})
 
-		var env []string
-		err := c.Call(ctx, httpclient.Request{
-			Method:  "GET",
-			Route:   "/api/env",
-			Decoder: httpclient.NewJSONDecoder(&env),
+		var res *Result
+		t.Run("Start service", func(t *testing.T) {
+			var err error
+			res, err = r.Run("the-server-name", binary, "e=e")
+			assert.Assert(t, err)
 		})
-		assert.Check(t, err)
-		assert.Check(t, cmp.DeepEqual([]string{"a=a", "b=b", "c=c", "d=d", "e=e"}, env))
-	})
 
-	t.Run("Get port", func(t *testing.T) {
-		tests := []struct {
-			name       string
-			line       string
-			expectPort string
-		}{
-			{
-				"ipv4",
-				"server: new-server app.address=127.0.0.1:80 asdasdasdsa",
-				"80",
-			},
-			{
-				"ipv6",
-				"server: new-server app.address=[::]:80 asdasdasdsa",
-				"80",
-			},
-			{
-				"invalid",
-				"app.address=:80 asdasdasdsa",
-				"",
-			},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				assert.Check(t, cmp.Equal(getPort([]string{tt.line}, "", ""), tt.expectPort))
+		t.Run("Check the right environment was set", func(t *testing.T) {
+			c := httpclient.New(httpclient.Config{
+				Name:       "the-client-name",
+				BaseURL:    res.APIAddr(),
+				AcceptType: httpclient.JSON,
+				Timeout:    2 * time.Second,
 			})
-		}
+
+			var env []string
+			err := c.Call(ctx, httpclient.Request{
+				Method:  "GET",
+				Route:   "/api/env",
+				Decoder: httpclient.NewJSONDecoder(&env),
+			})
+			assert.Check(t, err)
+			assert.Check(t, cmp.DeepEqual([]string{"a=a", "b=b", "c=c", "d=d", "e=e"}, env))
+		})
 	})
+
+	t.Run("admin_only", func(t *testing.T) {
+		r := New()
+		t.Cleanup(func() {
+			assert.Check(t, r.Stop())
+		})
+		t.Run("start_service", func(t *testing.T) {
+			var err error
+			_, err = r.Run("", binary, "ADMIN_ONLY=true")
+			assert.Assert(t, err)
+		})
+	})
+
+	t.Run("no_api", func(t *testing.T) {
+		r := New()
+		t.Cleanup(func() {
+			assert.Check(t, r.Stop())
+		})
+		t.Run("start_service_fail", func(t *testing.T) {
+			result, err := r.Start(binary, "ADMIN_ONLY=true")
+			assert.NilError(t, err)
+			defer func() { _ = result.Stop() }()
+
+			err = result.Ready("not-the-server-name", time.Second)
+			assert.ErrorContains(t, err, "timeout hit")
+		})
+	})
+}
+
+func TestGetPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		line       string
+		expectPort string
+	}{
+		{
+			"ipv4",
+			"server: new-server app.address=127.0.0.1:80 asdasdasdsa",
+			"80",
+		},
+		{
+			"ipv6",
+			"server: new-server app.address=[::]:80 asdasdasdsa",
+			"80",
+		},
+		{
+			"invalid",
+			"app.address=:80 asdasdasdsa",
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Check(t, cmp.Equal(getPort([]string{tt.line}, "", ""), tt.expectPort))
+		})
+	}
 }


### PR DESCRIPTION
Which means that we need to be able to allow for services which
dont have an API

Add a new Ready method to expose the readiness internals so callers
can control the timeout and when the serverName is empty then dont
test for the server port, to handle non api services.