### PR TITLE
Support tags in MetricProducer gauge metrics

### DIFF
--- a/system/metrics.go
+++ b/system/metrics.go
@@ -20,6 +20,10 @@ type MetricProducer interface {
 	Gauges(context.Context) map[string]float64
 }
 
+type tagProducer interface {
+	Tags(context.Context) map[string][]string
+}
+
 func traceMetrics(ctx context.Context, producers []MetricProducer) {
 	metrics := o11y.FromContext(ctx).MetricsProvider()
 	for _, producer := range producers {
@@ -29,9 +33,13 @@ func traceMetrics(ctx context.Context, producers []MetricProducer) {
 
 func traceMetric(ctx context.Context, provider o11y.MetricsProvider, producer MetricProducer) {
 	producerName := strings.Replace(producer.MetricName(), "-", "_", -1)
+	var tags map[string][]string
+	if p, ok := producer.(tagProducer); ok {
+		tags = p.Tags(ctx)
+	}
 	for f, v := range producer.Gauges(ctx) {
 		scopedField := fmt.Sprintf("gauge.%s.%s", producerName, f)
-		_ = provider.Gauge(scopedField, v, []string{}, 1)
+		_ = provider.Gauge(scopedField, v, tags[f], 1)
 	}
 }
 

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -64,14 +64,14 @@ func TestSystem_Run(t *testing.T) {
 			Metric: "gauge",
 			Name:   "gauge..key_a",
 			Value:  1,
-			Tags:   []string{},
+			Tags:   []string{"foo:bar"},
 			Rate:   1,
 		},
 		{
 			Metric: "gauge",
 			Name:   "gauge..key_b",
 			Value:  2,
-			Tags:   []string{},
+			Tags:   []string{"baz:qux"},
 			Rate:   1,
 		},
 		{
@@ -96,7 +96,7 @@ type mockMetricProducer struct {
 }
 
 func newMockMetricProducer(wg *sync.WaitGroup) *mockMetricProducer {
-	wg.Add(2)
+	wg.Add(3)
 	return &mockMetricProducer{wg: wg}
 }
 
@@ -110,6 +110,14 @@ func (m *mockMetricProducer) Gauges(_ context.Context) map[string]float64 {
 	return map[string]float64{
 		"key_a": 1,
 		"key_b": 2,
+	}
+}
+
+func (m *mockMetricProducer) Tags(_ context.Context) map[string][]string {
+	m.wg.Done()
+	return map[string][]string{
+		"key_a": {"foo:bar"},
+		"key_b": {"baz:qux"},
 	}
 }
 


### PR DESCRIPTION
To use tags, the MetricProducer will also need to implement the
tagProducer interface. This was implemented as an additional interface
to maintain compatibility with library consumers.