### PR TITLE
`mongoex`: Give back a Mongo client, rather than a database

### DIFF
--- a/mongoex/system_test.go
+++ b/mongoex/system_test.go
@@ -1,27 +1,33 @@
 package mongoex
 
 import (
+	"errors"
 	"testing"
 
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"gotest.tools/v3/assert"
 
+	"github.com/circleci/ex/system"
 	"github.com/circleci/ex/testing/testcontext"
 )
 
-func TestNew(t *testing.T) {
+func TestLoad(t *testing.T) {
 	ctx := testcontext.Background()
 	cfg := Config{
 		URI:    "mongodb://root:password@localhost:27017",
 		UseTLS: false,
 	}
 
-	client, err := New(ctx, "connection-test", cfg)
-	assert.NilError(t, err)
+	sys := system.New()
+	defer sys.Cleanup(ctx)
+
+	client, err := Load(ctx, "connection-test", cfg, sys)
+	assert.Assert(t, err)
 	t.Cleanup(func() {
-		t.Run("Disconnect client", func(t *testing.T) {
+		t.Run("Check client is already disconnected", func(t *testing.T) {
 			err := client.Disconnect(ctx)
-			assert.NilError(t, err)
+			assert.Check(t, errors.Is(err, mongo.ErrClientDisconnected))
 		})
 	})
 
@@ -29,15 +35,4 @@ func TestNew(t *testing.T) {
 		err = client.Ping(ctx, readpref.SecondaryPreferred())
 		assert.Assert(t, err)
 	})
-}
-
-func TestNew_InvalidURLDoesNotLeak(t *testing.T) {
-	ctx := testcontext.Background()
-	cfg := Config{
-		URI:    "mongodb://root:]@localhost:27017",
-		UseTLS: false,
-	}
-
-	_, err := New(ctx, "connection-test", cfg)
-	assert.Error(t, err, "mongoex: failed to parse URI: net/url: invalid userinfo")
 }


### PR DESCRIPTION
- We don't want to limit what users can configure / use the mongo driver for.
- Also take a full mongo client options struct (though we always override the URL / client name).