### PR TITLE
Emit o11y middleware metrics using MetricsProvider interface

### DIFF
--- a/o11y/wrappers/o11ynethttp/o11ynethttp_test.go
+++ b/o11y/wrappers/o11ynethttp/o11ynethttp_test.go
@@ -1,0 +1,130 @@
+package o11ynethttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"golang.org/x/sync/errgroup"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/circleci/ex/httpclient"
+	"github.com/circleci/ex/httpserver"
+	"github.com/circleci/ex/o11y"
+	"github.com/circleci/ex/o11y/honeycomb"
+	"github.com/circleci/ex/testing/fakemetrics"
+)
+
+func TestMiddleware(t *testing.T) {
+	m := &fakemetrics.Provider{}
+
+	ctx := o11y.WithProvider(context.Background(), honeycomb.New(honeycomb.Config{
+		Format:  "color",
+		Metrics: m,
+	}))
+	provider := o11y.FromContext(ctx)
+	t.Cleanup(func() {
+		provider.Close(ctx)
+		t.Run("Check metrics", func(t *testing.T) {
+
+			assert.Check(t, cmp.DeepEqual(
+				[]fakemetrics.MetricCall{
+					{
+						Metric: "timer",
+						Name:   "handler",
+						Value:  1,
+						Tags: []string{
+							"server_name:test-server",
+							"request.method:POST",
+							"request.route:unknown",
+							"response.status_code:200",
+						},
+						Rate: 1,
+					},
+					{
+						Metric: "timer",
+						Name:   "httpclient",
+						Value:  1,
+						Tags: []string{
+							"http.client_name:test-client",
+							"http.route:/api/%s",
+							"http.method:POST",
+							"http.status_code:200",
+							"http.retry:false",
+						},
+						Rate: 1,
+					},
+					{
+						Metric: "timer",
+						Name:   "handler",
+						Value:  1,
+						Tags: []string{
+							"server_name:test-server",
+							"request.method:POST",
+							"request.route:unknown",
+							"response.status_code:404",
+						},
+						Rate: 1,
+					},
+					{
+						Metric: "timer",
+						Name:   "httpclient",
+						Value:  1,
+						Tags: []string{
+							"http.client_name:test-client",
+							"http.route:/api/%s",
+							"http.method:POST",
+							"http.status_code:404",
+							"http.retry:false",
+						},
+						Rate: 1,
+					},
+				},
+				m.Calls(), fakemetrics.CMPMetrics, cmpopts.IgnoreFields(fakemetrics.MetricCall{}, "Value", "ValueInt")),
+			)
+		})
+	})
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	r := http.NewServeMux()
+	r.HandleFunc("/api/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/exists":
+			_, _ = io.WriteString(w, "exists")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	srv, err := httpserver.New(ctx, "test-server", "127.0.0.1:0", Middleware(provider, "test-server", r))
+	assert.Assert(t, err)
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return srv.Serve(ctx)
+	})
+	t.Cleanup(func() {
+		assert.Check(t, g.Wait())
+	})
+
+	client := httpclient.New(httpclient.Config{
+		Name:    "test-client",
+		BaseURL: "http://" + srv.Addr(),
+	})
+
+	t.Run("Hit an ID that exists", func(t *testing.T) {
+		err = client.Call(ctx, httpclient.NewRequest("POST", "/api/%s", time.Second, "exists"))
+		assert.Assert(t, err)
+	})
+
+	t.Run("Hit an ID that does not exist", func(t *testing.T) {
+		err = client.Call(ctx, httpclient.NewRequest("POST", "/api/%s", time.Second, "does-not-exist"))
+		assert.Check(t, httpclient.HasStatusCode(err, http.StatusNotFound))
+	})
+}

--- a/testing/fakemetrics/fakemetrics.go
+++ b/testing/fakemetrics/fakemetrics.go
@@ -18,7 +18,7 @@ type MetricCall struct {
 }
 
 var CMPMetrics = gocmp.Options{
-	cmpopts.EquateApprox(0, 4),
+	cmpopts.EquateApprox(0, 10),
 	cmpopts.SortSlices(func(x, y MetricCall) bool {
 		const format = "%s|%s|%s"
 		return fmt.Sprintf(format, x.Metric, x.Name, x.Tags) <


### PR DESCRIPTION
- This means that if the spans get sampled, we still get metrics