### PR TITLE
Wire in honeycomb key and service name

### DIFF
--- a/config/o11y/o11y.go
+++ b/config/o11y/o11y.go
@@ -130,6 +130,7 @@ func honeyComb(o Config) (honeycomb.Config, error) {
 		SampleTraces:  o.SampleTraces,
 		SampleKeyFunc: o.SampleKeyFunc,
 		SampleRates:   o.SampleRates,
+		ServiceName:   o.Service,
 		Debug:         o.Debug,
 	}
 	return conf, conf.Validate()

--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"time"
 
-	beeline "github.com/honeycombio/beeline-go"
+	"github.com/honeycombio/beeline-go"
 	"github.com/honeycombio/beeline-go/client"
 	"github.com/honeycombio/beeline-go/trace"
 	"github.com/honeycombio/dynsampler-go"
-	libhoney "github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
 
 	"github.com/circleci/ex/o11y"
@@ -36,6 +36,7 @@ type Config struct {
 	SampleRates   map[string]int
 	Writer        io.Writer
 	Metrics       o11y.ClosableMetricsProvider
+	ServiceName   string
 
 	Debug bool
 }
@@ -101,8 +102,10 @@ func New(conf Config) o11y.Provider {
 	})
 
 	bc := beeline.Config{
-		Client: client,
-		Debug:  conf.Debug,
+		Client:      client,
+		Debug:       conf.Debug,
+		WriteKey:    conf.Key,
+		ServiceName: conf.ServiceName,
 	}
 
 	if conf.SampleTraces {

--- a/o11y/honeycomb/honeycomb_test.go
+++ b/o11y/honeycomb/honeycomb_test.go
@@ -31,15 +31,18 @@ func TestHoneycomb(t *testing.T) {
 		assert.Check(t, cmp.Contains(event, `"raw_key":"span-value"`), "span.AddRawField is unprefixed")
 		assert.Check(t, cmp.Contains(event, `"app.another_key":"span-value"`), "o11y.AddField is prefixed")
 		assert.Check(t, cmp.Contains(event, `"app.trace_key":"trace-value"`), "o11y.AddFieldToTrace is prefixed")
+		assert.Check(t, cmp.Contains(event, `"service_name":"a-service-name"`))
 	}
 	// set up a minimal server with the check defined above
 	url := honeycombServer(t, check)
 	ctx := context.Background()
 
 	h := New(Config{
-		Dataset:    "test-dataset",
-		Host:       url,
-		SendTraces: true,
+		Dataset:     "test-dataset",
+		Host:        url,
+		SendTraces:  true,
+		Key:         "a-key",
+		ServiceName: "a-service-name",
 	})
 
 	h.AddGlobalField("version", 42)
@@ -58,9 +61,11 @@ func TestHoneycomb(t *testing.T) {
 
 func TestHoneycomb_ValidatesKeys(t *testing.T) {
 	h := New(Config{
-		Dataset:    "test-dataset",
-		Host:       "invalid-url",
-		SendTraces: true,
+		Dataset:     "test-dataset",
+		Host:        "invalid-url",
+		SendTraces:  true,
+		Key:         "a-key",
+		ServiceName: "a-service-name",
 	})
 
 	recovery := func(key string) {
@@ -113,9 +118,11 @@ func TestHoneycombMetricsDoesntPolluteWhenNotConfigured(t *testing.T) {
 	ctx := context.Background()
 
 	h := New(Config{
-		Dataset:    "test-dataset",
-		Host:       url,
-		SendTraces: true,
+		Dataset:     "test-dataset",
+		Host:        url,
+		SendTraces:  true,
+		Key:         "a-key",
+		ServiceName: "a-service-name",
 	})
 	h.AddGlobalField("version", 42)
 
@@ -138,10 +145,12 @@ func TestHoneycombMetrics(t *testing.T) {
 
 	fakeMetrics := &fakemetrics.Provider{}
 	h := New(Config{
-		Dataset:    "test-dataset",
-		Host:       url,
-		SendTraces: true,
-		Metrics:    fakeMetrics,
+		Dataset:     "test-dataset",
+		Host:        url,
+		SendTraces:  true,
+		Metrics:     fakeMetrics,
+		Key:         "a-key",
+		ServiceName: "a-service-name",
 	})
 	h.AddGlobalField("version", 42)
 
@@ -231,9 +240,11 @@ func TestHoneycombWithError(t *testing.T) {
 	ctx := context.Background()
 
 	h := New(Config{
-		Dataset:    "error-dataset",
-		Host:       url,
-		SendTraces: true,
+		Dataset:     "error-dataset",
+		Host:        url,
+		SendTraces:  true,
+		Key:         "a-key",
+		ServiceName: "a-service-name",
 	})
 
 	_ = func() (err error) {
@@ -261,9 +272,11 @@ func TestHoneycombWithNilError(t *testing.T) {
 	ctx := context.Background()
 
 	h := New(Config{
-		Dataset:    "error-dataset",
-		Host:       url,
-		SendTraces: true,
+		Dataset:     "error-dataset",
+		Host:        url,
+		SendTraces:  true,
+		Key:         "a-key",
+		ServiceName: "a-service-name",
 	})
 
 	_, _ = func() (result string, err error) {


### PR DESCRIPTION
- Key is technically not needed as we have a custom client, but it
  supresses the warning from beeline-go
