### PR TITLE
SRENG-358: Allow Custom Honeycomb Host for Refinery

### DIFF
--- a/config/o11y/o11y.go
+++ b/config/o11y/o11y.go
@@ -20,6 +20,7 @@ type Config struct {
 	RollbarServerRoot string
 	HoneycombEnabled  bool
 	HoneycombDataset  string
+	HoneycombHost     string
 	HoneycombKey      secret.String
 	SampleTraces      bool
 	SampleKeyFunc     func(map[string]interface{}) string
@@ -122,7 +123,7 @@ func honeyComb(o Config) (honeycomb.Config, error) {
 	}
 
 	conf := honeycomb.Config{
-		Host:          "",
+		Host:          o.HoneycombHost,
 		Dataset:       o.HoneycombDataset,
 		Key:           string(o.HoneycombKey),
 		Format:        o.Format,


### PR DESCRIPTION
An optional feature that will enable users to leverage Refinery. The change is backward compatible as current library users will be using an empty string that defaults to Honeycomb Public API.

We are already allowing custom Honeycomb Hosts for internal testing. Now we will expose this option to end-users.