### PR TITLE
RT-456/add cloud metadata client

### DIFF
--- a/cloudenv/config.go
+++ b/cloudenv/config.go
@@ -1,0 +1,21 @@
+package cloudenv
+
+import "github.com/circleci/ex/config/secret"
+
+type Config struct {
+	Provider      Provider
+	RunnerAPIBase string
+	CreationToken secret.String
+
+	// Optional
+	TestMetadataBaseURL string
+	TestSymlinkDir      string
+	TestSkipWarmUp      bool
+}
+
+func (cfg Config) testMetadataBaseURL(s string) string {
+	if cfg.TestMetadataBaseURL != "" {
+		return cfg.TestMetadataBaseURL
+	}
+	return s
+}

--- a/cloudenv/metadataclient.go
+++ b/cloudenv/metadataclient.go
@@ -1,0 +1,74 @@
+package cloudenv
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/circleci/ex/httpclient"
+)
+
+type metadataClient interface {
+	ExternalID(ctx context.Context) (externalID string, err error)
+	PublicIP(ctx context.Context) (publicIP string, err error)
+}
+
+func NewMetadataClient(cfg Config) (metadataClient, error) {
+	clientConfig := httpclient.Config{
+		Name:    "machine-agent",
+		Timeout: 5 * time.Second,
+	}
+	switch cfg.Provider {
+	case ProviderEC2:
+		clientConfig.BaseURL = cfg.testMetadataBaseURL("http://169.254.169.254")
+		return &ec2MetadataClient{
+			client: httpclient.New(clientConfig),
+		}, nil
+	case ProviderGCE:
+		clientConfig.BaseURL = cfg.testMetadataBaseURL("http://metadata.google.internal")
+		return &gceMetadataClient{
+			client: httpclient.New(clientConfig),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown provider: %q", cfg.Provider)
+	}
+}
+
+type ec2MetadataClient struct {
+	client *httpclient.Client
+}
+
+func (c *ec2MetadataClient) ExternalID(ctx context.Context) (externalID string, err error) {
+	err = c.client.Call(ctx, httpclient.NewRequest("GET", "/latest/meta-data/instance-id",
+		httpclient.StringDecoder(&externalID),
+	))
+	return externalID, err
+}
+
+func (c *ec2MetadataClient) PublicIP(ctx context.Context) (publicIP string, err error) {
+	err = c.client.Call(ctx, httpclient.NewRequest("GET", "/latest/meta-data/public-ipv4",
+		httpclient.StringDecoder(&publicIP),
+	))
+	return publicIP, err
+}
+
+type gceMetadataClient struct {
+	client *httpclient.Client
+}
+
+func (c *gceMetadataClient) ExternalID(ctx context.Context) (externalID string, err error) {
+	err = c.client.Call(ctx, httpclient.NewRequest("GET", "/computeMetadata/v1/instance/id",
+		httpclient.Header("Metadata-Flavor", "Google"),
+		httpclient.StringDecoder(&externalID),
+	))
+	return externalID, err
+}
+
+func (c *gceMetadataClient) PublicIP(ctx context.Context) (publicIP string, err error) {
+	err = c.client.Call(ctx, httpclient.NewRequest(
+		"GET", "/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip",
+		httpclient.Header("Metadata-Flavor", "Google"),
+		httpclient.StringDecoder(&publicIP),
+	))
+	return publicIP, err
+}

--- a/cloudenv/provider.go
+++ b/cloudenv/provider.go
@@ -1,0 +1,37 @@
+package cloudenv
+
+import "fmt"
+
+type Provider int
+
+const (
+	ProviderUnknown Provider = iota
+	ProviderEC2
+	ProviderGCE
+)
+
+func (p Provider) String() string {
+	strings := [...]string{"UNKNOWN", "EC2", "GCE"}
+
+	// prevent panicking in case of status is out-of-range
+	if p < ProviderUnknown || p > ProviderGCE {
+		return strings[0]
+	}
+
+	return strings[p]
+}
+
+func (p *Provider) UnmarshalText(text []byte) error {
+	s := string(text)
+
+	provider, ok := map[string]Provider{
+		"EC2": ProviderEC2,
+		"GCE": ProviderGCE,
+	}[s]
+	if !ok {
+		return fmt.Errorf("unknown provider: %q", s)
+	}
+
+	*p = provider
+	return nil
+}

--- a/cloudenv/provider_test.go
+++ b/cloudenv/provider_test.go
@@ -1,0 +1,91 @@
+package cloudenv
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestProvider_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider Provider
+		want     string
+	}{
+		{
+			name:     "EC2",
+			provider: ProviderEC2,
+			want:     "EC2",
+		},
+		{
+			name:     "GCE",
+			provider: ProviderGCE,
+			want:     "GCE",
+		},
+		{
+			name:     "Unknown provider",
+			provider: ProviderUnknown,
+			want:     "UNKNOWN",
+		},
+		{
+			name:     "Negative provider",
+			provider: -1,
+			want:     "UNKNOWN",
+		},
+		{
+			name:     "Out of range provider",
+			provider: 3,
+			want:     "UNKNOWN",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Check(t, cmp.Equal(tt.provider.String(), tt.want))
+		})
+	}
+}
+
+func TestProvider_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         []byte
+		wantProvider Provider
+		wantError    string
+	}{
+		{
+			name:         "Read EC2",
+			text:         []byte("EC2"),
+			wantProvider: ProviderEC2,
+		},
+		{
+			name:         "Read GCE",
+			text:         []byte("GCE"),
+			wantProvider: ProviderGCE,
+		},
+		{
+			name:         "Invalid provider",
+			text:         []byte("this is invalid"),
+			wantProvider: ProviderUnknown,
+			wantError:    `unknown provider: "this is invalid"`,
+		},
+		{
+			name:         "Nil input",
+			text:         nil,
+			wantProvider: ProviderUnknown,
+			wantError:    `unknown provider: ""`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p Provider
+			err := p.UnmarshalText(tt.text)
+			if tt.wantError != "" {
+				assert.Check(t, cmp.ErrorContains(err, tt.wantError))
+			} else {
+				assert.Check(t, err)
+			}
+			assert.Check(t, cmp.Equal(p, tt.wantProvider))
+		})
+	}
+}


### PR DESCRIPTION
Migrating the cloud instance [metadata client from machine-provisioner](https://github.com/circleci/machine-provisioner/blob/feaeb2b90d8174d6c581472d9d46539f634ea824/agent/metadataclient.go) to `ex` for use in other agents as well. 