### PR TITLE
Add grpc helpers for better behaviour and to avoid proxy bugs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,11 @@ require (
 )
 
 require (
+	golang.org/x/net v0.0.0-20210913180222-943fd674d43e
+	google.golang.org/grpc v1.43.0
+)
+
+require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
@@ -60,7 +65,7 @@ require (
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/grpc v1.43.0 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -623,6 +623,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/grpc/config.go
+++ b/grpc/config.go
@@ -1,0 +1,37 @@
+// Package grpchelpers includes helpers to set up grpc connections.
+package grpc
+
+import "fmt"
+
+// ServiceConfig returns a JSON-encoded service config. Takes a
+// service name as defined in the service's .proto file
+// (e.g. "package.ServiceName").
+func ServiceConfig(serviceName string) string {
+	return fmt.Sprintf(serviceConfigJSON, serviceName)
+}
+
+const serviceConfigJSON = `
+{
+  "loadBalancingConfig": [ { "round_robin": {} } ],
+  "methodConfig": [
+    {
+      "name": [
+        {
+          "service": "%s"
+        }
+      ],
+
+      "retryPolicy": {
+        "maxAttempts": 3,
+        "initialBackoff": "0.5s",
+        "maxBackoff": "2s",
+        "backoffMultiplier": 1.5,
+        "retryableStatusCodes": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ]
+      }
+    }
+  ]
+}
+`

--- a/grpc/dial.go
+++ b/grpc/dial.go
@@ -1,0 +1,18 @@
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func Dial(ctx context.Context, host, serviceName string) (*grpc.ClientConn, error) {
+	return grpc.DialContext(
+		ctx,
+		ProxyProofTarget(host),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+		grpc.WithDefaultServiceConfig(ServiceConfig(serviceName)),
+	)
+}

--- a/grpc/proxy.go
+++ b/grpc/proxy.go
@@ -1,0 +1,65 @@
+package grpc
+
+import (
+	"net/url"
+
+	"golang.org/x/net/http/httpproxy"
+)
+
+// ProxyProofTarget takes the host and if there is no proxy in place in the environment at all or
+// if there is a proxy, but we should still use it for the given url, the returned host will include
+// the dns:// prefix.
+//
+// Note if this is used to avoid traffic going via a proxy then DNS based load balancing is disabled.
+//
+// A Note On Proxies.
+//
+// NO_PROXY domain names can't be honored with dns scheme because of https://github.com/grpc/grpc-go/issues/3401
+//
+// The following doc... https://github.com/grpc/grpc/blob/master/doc/naming.md suggests that if no scheme prefix
+// is used then the dns is used automatically, but this is a bit misleading.
+//
+// The dns scheme does a lookup for any SRV and multiple A records amongst other things, to set up a list of servers.
+// At this point the server addresses are all in the form ip:port. The thing is - nothing is actually connected at
+// this point, connections are made lazily. Using the dns scheme supports client side per request load balancing.
+//
+// If the dns scheme is not used then in fact go grpc uses a 'passthrough' scheme, which defers name resolution to the
+// standard (dns) resolver at connection (dial) time passing through the server name, resolving to one IP.
+// This obviously does not support client side per call balancing.
+//
+// The detection of a proxy only happens during dialing, and it is the proxy environment variables that indicate
+// whether a proxy should be used.
+//
+// In the 'passthrough' case because we have the full domain during dialing the client can compare this with the list
+// of domains in the NO_PROXY list. However, in the full dns scheme case we only have a list of IPs which don't match
+// anything in the NO_PROXY list - so they are duly proxied.
+func ProxyProofTarget(host string) string {
+	if goodProxySettings(host) {
+		return "dns:///" + host
+	}
+	return host
+}
+
+// goodProxySettings returns true if there is no proxy in place in the environment at all or
+// if there is a proxy and we should still use it for the given url. This is needed to
+// solve CIRCLE-25181.
+func goodProxySettings(host string) bool {
+	url, _ := url.Parse("https://" + host)
+
+	conf := httpproxy.FromEnvironment()
+	proxy, _ := conf.ProxyFunc()(url)
+	// if the environment suggests we should proxy this url then we can use the dns scheme
+	// as the ip's will be proxied.
+	if proxy != nil {
+		return true
+	}
+	// getting here means the environment suggests we should not proxy. Now we need to
+	// check if that is because of the no proxy list.
+	conf.NoProxy = ""
+	proxy, _ = conf.ProxyFunc()(url)
+
+	// If there is no proxy configured in the environment at all
+	// then we are safe. Otherwise the proxy exists because we are ignoring no proxy.
+	// In this case we can not use dns scheme (as it ignores no proxy).
+	return proxy == nil
+}

--- a/grpc/proxy_test.go
+++ b/grpc/proxy_test.go
@@ -1,0 +1,67 @@
+package grpc
+
+import (
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGoodProxySettings(t *testing.T) {
+	// N.B. can not be run in parallel, as we mess with the operational environment
+	// related to proxy settings.
+	const (
+		proxyEnvKey   = "https_proxy"
+		noProxyEnvKey = "no_proxy"
+		hostName      = "hostname.com"
+	)
+	// reset all the proxy related env vars (they will be restored on cleanup)
+	for _, k := range []string{
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"NO_PROXY",
+		"http_proxy",
+		proxyEnvKey,
+		noProxyEnvKey,
+	} {
+		t.Setenv(k, "")
+	}
+
+	for _, tc := range []struct {
+		name     string
+		proxy    string
+		noProxy  string
+		expected bool
+	}{
+		{
+			name:     "no proxy",
+			proxy:    "",
+			noProxy:  "",
+			expected: true,
+		},
+		{
+			name:     "mismatched proxy",
+			proxy:    "no-match.com",
+			noProxy:  "",
+			expected: true,
+		},
+		{
+			name:     "matched proxy",
+			proxy:    hostName,
+			noProxy:  "",
+			expected: true,
+		},
+		{
+			name:     "matched proxy matched no proxy",
+			proxy:    hostName,
+			noProxy:  hostName,
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = os.Setenv(proxyEnvKey, tc.proxy)
+			_ = os.Setenv(noProxyEnvKey, tc.noProxy)
+			assert.Equal(t, tc.expected, goodProxySettings(hostName))
+		})
+	}
+}


### PR DESCRIPTION
We are seeing the gRPC bug (as mentioned in the comments) in any of our grpc clients when running in an environment with a proxy