### PR TITLE
Add a transport mutating config option.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	gotest.tools/v3 v3.1.0
 )
 
+require golang.org/x/net v0.0.0-20210913180222-943fd674d43e
+
 require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -58,6 +58,8 @@ type Config struct {
 	UserAgent string
 	// Transport allows overriding the default HTTP transport the client will use.
 	Transport *http.Transport
+	// TransportModifier can modify the transport after the client has applied other config settings
+	TransportModifier func(Transport *http.Transport)
 	// Tracer allows http stats tracing to be enabled.
 	Tracer tracer
 	// DialContext allows a dial context to be injected into the HTTP transport.
@@ -92,6 +94,9 @@ func New(cfg Config) *Client {
 		cfg.Transport.MaxConnsPerHost = cfg.MaxConnectionsPerHost
 		cfg.Transport.MaxIdleConnsPerHost = cfg.MaxConnectionsPerHost
 		cfg.Transport.DialContext = cfg.DialContext
+	}
+	if cfg.TransportModifier != nil {
+		cfg.TransportModifier(cfg.Transport)
 	}
 
 	additionalHeaders := make(map[string]string)

--- a/httpclient/proxy_test.go
+++ b/httpclient/proxy_test.go
@@ -1,0 +1,52 @@
+package httpclient_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type fwdProxy struct {
+	URL        string
+	ProxiedURL string
+}
+
+func startFwdProxy(t *testing.T) *fwdProxy {
+	p := &fwdProxy{}
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodConnect { // tunnelling not supported
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			} else {
+				p.handleHTTP(w, r)
+			}
+		}))
+	p.URL = server.URL
+	t.Cleanup(server.Close)
+	return p
+}
+
+func (p *fwdProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
+	p.ProxiedURL = r.URL.String()
+
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DialContext = localhostDialler()
+	t.Proxy = nil
+
+	resp, err := t.RoundTrip(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	defer resp.Body.Close()
+	for k, vv := range w.Header() {
+		for _, v := range vv {
+			resp.Header.Add(k, v)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}


### PR DESCRIPTION
If we want to change one thing on the transport, we currently have
to repeat all the connection options, this allows us to provide a
way to override transport options after the standard setup.

I added this primarily to explicitly disable clients honouring proxies - we could add that as a specific config option
but this felt a bit more flexible.