### PR TITLE
Add AddTraceField to honeycomb wrapper

### DIFF
--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -334,6 +334,22 @@ func (s *span) AddRawField(key string, val interface{}) {
 	s.span.AddField(key, val)
 }
 
+func (s *span) AddTraceField(key string, val interface{}) {
+	mustValidateKey(key)
+	if err, ok := val.(error); ok {
+		val = err.Error()
+	}
+	s.span.AddTraceField("app."+key, val)
+}
+
+func (s *span) AddRawTraceField(key string, val interface{}) {
+	mustValidateKey(key)
+	if err, ok := val.(error); ok {
+		val = err.Error()
+	}
+	s.span.AddTraceField(key, val)
+}
+
 func (s *span) RecordMetric(metric o11y.Metric) {
 	s.metrics = append(s.metrics, metric)
 	// Stash the metrics list as a span field, the pre-send hook will fish it out

--- a/o11y/o11y.go
+++ b/o11y/o11y.go
@@ -73,6 +73,16 @@ type Span interface {
 	// https://github.com/open-telemetry/opentelemetry-specification/tree/7ae3d066c95c716ef3086228ef955d84ba03ac88/specification/trace/semantic_conventions
 	AddRawField(key string, val interface{})
 
+	// AddTraceField is for adding application-level information to all spans in the trace
+	// Generally AddField is preferred unless having the field on all spans is useful.
+	//
+	// Any field name will be prefixed with "app."
+	AddTraceField(key string, val interface{})
+
+	// AddRawTraceField is for adding useful information to the trace in library/plumbing code
+	// Review using AddField() AddRawField() and AddTraceField() before choosing this function.
+	AddRawTraceField(key string, val interface{})
+
 	// RecordMetric tells the provider to emit a metric to its metric backend when the span ends
 	RecordMetric(metric Metric)
 
@@ -313,6 +323,10 @@ func (s *noopSpan) SerializeHeaders() string {
 func (s *noopSpan) AddField(key string, val interface{}) {}
 
 func (s *noopSpan) AddRawField(key string, val interface{}) {}
+
+func (s *noopSpan) AddTraceField(key string, val interface{}) {}
+
+func (s *noopSpan) AddRawTraceField(key string, val interface{}) {}
 
 func (s *noopSpan) RecordMetric(metric Metric) {}
 


### PR DESCRIPTION
This adds the ability for anyone using `o11y.Span` and/or `o11y.honeycomb` to use [Span.AddTraceField](https://pkg.go.dev/github.com/honeycombio/beeline-go/trace#Span.AddTraceField). This function allows a field to be added to all spans in a trace, which is useful when filtering spans later or when setting up sampling rules.

This changes the `o11y.Span` Interface, so it's potentially a breaking change for anything that implements it.  