### PR TITLE
Add worker loop name to root span

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -80,7 +80,7 @@ func doWork(provider o11y.Provider, cfg Config) (backoff time.Duration) {
 
 	ctx = o11y.WithProvider(ctx, provider)
 	ctx, span := provider.StartSpan(ctx, fmt.Sprintf("worker loop: %s", cfg.Name))
-	span.AddField("loop_name", cfg.Name)
+	o11y.AddFieldToTrace(ctx, "loop_name", cfg.Name)
 	span.AddRawField("meta.type", "worker_loop")
 
 	span.RecordMetric(o11y.Timing("worker_loop", "loop_name", "result"))


### PR DESCRIPTION
This moves the `app.loop_name` field from the first span in the trace to the root span (which results in the field being available on all spans in the trace)

The name of the field doesn't change so this isn't a breaking change.

This allows us to more easily add sampling to worker loops.

For example:
```golang
		SampleTraces: true,
		SampleKeyFunc: func(fields map[string]interface{}) string {
			return fmt.Sprintf("%s %s",
				fields["app.loop_name"],
				fields["result"],
			)
		},
		SampleRates: map[string]int{
			"myLoop success": 1e3,
		},
```

Previously the above sampling would only filter out the initial span since it was the only one to have the `app.loop_name`, all other spans in the trace would still be kept.

Now since the field does exist on all spans the sampling works for the whole worker loop. (What still doesn't work is fully maintaining the span in the error case, `result` is also only set per span, so in the case that there is an error, you still only end up with the single orphan span that failed)