### PR TITLE
Abstract o11y http propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 // indirect
 	github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 // indirect
-	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,7 +111,6 @@ github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpm
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=

--- a/o11y/wrappers/o11ygin/o11ygin.go
+++ b/o11y/wrappers/o11ygin/o11ygin.go
@@ -8,11 +8,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/honeycombio/beeline-go/propagation"
-	"github.com/honeycombio/beeline-go/trace"
 
 	"github.com/circleci/ex/o11y"
-	"github.com/circleci/ex/o11y/honeycomb"
 	"github.com/circleci/ex/o11y/wrappers/baggage"
 )
 
@@ -99,19 +96,15 @@ func Recovery() func(c *gin.Context) {
 	})
 }
 
-func startSpanOrTraceFromHTTP(ctx context.Context, c *gin.Context, p o11y.Provider, serverName string) (
-	context.Context, o11y.Span) {
+func startSpanOrTraceFromHTTP(ctx context.Context,
+	c *gin.Context, p o11y.Provider, serverName string) (context.Context, o11y.Span) {
 
 	span := p.GetSpan(ctx)
 	if span == nil {
 		// there is no trace yet. We should make one! and use the root span.
-		beelineHeader := c.Request.Header.Get(propagation.TracePropagationHTTPHeader)
-		prop, _ := propagation.UnmarshalHoneycombTraceContext(beelineHeader)
-
-		var tr *trace.Trace
-		ctx, tr = trace.NewTrace(ctx, prop)
-		span = honeycomb.WrapSpan(tr.GetRootSpan())
+		ctx, span := p.Helpers().InjectPropagation(ctx, o11y.PropagationContextFromHeader(c.Request.Header))
 		span.AddRawField("name", fmt.Sprintf("http-server %s: %s %s", serverName, c.Request.Method, c.FullPath()))
+		return ctx, span
 	} else {
 		// we had a parent! let's make a new child for this handler
 		ctx, span = o11y.StartSpan(ctx, fmt.Sprintf("http-server %s: %s %s", serverName, c.Request.Method, c.FullPath()))


### PR DESCRIPTION
Introduce the construction of helpers, for some stuff that is not part of the main o11y provider interface 

two helpers for http propagation
one helper for improved more generic testability