### PR TITLE
Add Backstage catalog file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ex
+  description: Common Go packages for the execution teams
+  annotations:
+    circleci.com/project-slug: github/circleci/ex
+    snyk.io/org-name: circleci-78h
+    snyk.io/project-ids: cd2554cd-8913-49b1-a797-7165fdc7a75e
+  links:
+    - title: Documentation
+      url: https://pkg.go.dev/github.com/circleci/ex
+      icon: docs
+  tags:
+    - go
+spec:
+  type: library
+  lifecycle: production
+  owner: execution


### PR DESCRIPTION
This adds the Backstage YAML file to ex, so it can be discovered and added to the catalog. This will help increase discoverability and allow us to refer to it as a dependency in other projects.