### PR TITLE
Revert "Support disabling HTTP/2 support from the ex httpclient"

### DIFF
--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -6,7 +6,6 @@ package httpclient
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,8 +62,6 @@ type Config struct {
 	Tracer tracer
 	// DialContext allows a dial context to be injected into the HTTP transport.
 	DialContext func(ctx context.Context, network string, addr string) (net.Conn, error)
-	// DisableHTTP2 is used to force a client to use HTTP/1.1 regardless of the server-side support
-	DisableHTTP2 bool
 }
 
 // Client is the o11y instrumented http client.
@@ -112,14 +109,6 @@ func New(cfg Config) *Client {
 	if cfg.Tracer != nil {
 		roundTripper = cfg.Tracer.Wrap(cfg.Name, roundTripper)
 	}
-
-	if cfg.DisableHTTP2 {
-		if rt, ok := roundTripper.(*http.Transport); ok {
-			// disable HTTP/2
-			rt.TLSNextProto = map[string]func(authority string, c *tls.Conn) http.RoundTripper{}
-		}
-	}
-
 	return &Client{
 		name:                  cfg.Name,
 		baseURL:               cfg.BaseURL,

--- a/httpclient/httpclient_internal_test.go
+++ b/httpclient/httpclient_internal_test.go
@@ -2,7 +2,6 @@ package httpclient
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -331,17 +330,4 @@ func TestClient_ExplicitBackoff(t *testing.T) {
 		err = client.Call(context.Background(), req)
 		assert.Assert(t, err)
 	})
-}
-
-func TestClient_DisabledHTTP2(t *testing.T) {
-	client := New(Config{
-		Name:         "test",
-		BaseURL:      "https://circleci.com",
-		Timeout:      time.Second,
-		DisableHTTP2: true,
-	})
-
-	assert.Check(t, cmp.DeepEqual(
-		client.httpClient.Transport.(*http.Transport).TLSNextProto,
-		map[string]func(authority string, c *tls.Conn) http.RoundTripper{}))
 }


### PR DESCRIPTION
Reverts circleci/ex#391

**https://app.circleci.com/pipelines/github/circleci/build-agent-check/2684/workflows/a177619b-7483-4cd4-936f-4b6d121b9f10/jobs/14158**

This seems to break HTTP/1.1 connections over TLS. Reverting for now.