### PR TITLE
💛 Add standard metrics for warning and error [TASKS-1158]

### DIFF
--- a/o11y/wrappers/o11ygin/o11ygin_test.go
+++ b/o11y/wrappers/o11ygin/o11ygin_test.go
@@ -106,6 +106,21 @@ func TestMiddleware(t *testing.T) {
 					},
 					Rate: 1,
 				},
+				{
+					Metric:   "count",
+					Name:     "error",
+					ValueInt: 1,
+					Tags:     []string{"type:o11y"},
+					Rate:     1,
+				},
+
+				{
+					Metric:   "count",
+					Name:     "warning",
+					ValueInt: 1,
+					Tags:     []string{"type:o11y"},
+					Rate:     1,
+				},
 			},
 			m.Calls(), fakemetrics.CMPMetrics, cmpopts.IgnoreFields(fakemetrics.MetricCall{}, "Value", "ValueInt")),
 		)

--- a/o11y/wrappers/o11ynethttp/o11ynethttp_test.go
+++ b/o11y/wrappers/o11ynethttp/o11ynethttp_test.go
@@ -34,6 +34,13 @@ func TestMiddleware(t *testing.T) {
 			assert.Check(t, cmp.DeepEqual(
 				[]fakemetrics.MetricCall{
 					{
+						Metric:   "count",
+						Name:     "warning",
+						ValueInt: 1,
+						Tags:     []string{"type:o11y"},
+						Rate:     1,
+					},
+					{
 						Metric: "timer",
 						Name:   "handler",
 						Value:  1,

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -112,6 +112,13 @@ func TestSystem_Run(t *testing.T) {
 			Tags:   []string{"result:success"},
 			Rate:   1,
 		},
+		{
+			Metric:   "count",
+			Name:     "warning",
+			ValueInt: 1,
+			Tags:     []string{"type:o11y"},
+			Rate:     1,
+		},
 	}, cmpMetrics))
 }
 


### PR DESCRIPTION
This insects a span for the warning and error fields and produces a count metric tagged with the span name - which is relatively low cardinality, but adds enough context that the dashboards can help us zoom inot the problem

We use field names with an _error suffix to indicate a problem span but only in a path that can still make progress, e.g. a fail open path.

Since the field names are varied it is hard to add monitors, so this detects those fields, adds a standard 'failure' field to the span with the prefix part as the value and also produces a failure metric and uses the prefix part as a tag.