### PR TITLE
Remove the double path from testing releases DownloadLatest

### DIFF
--- a/testing/releases/latest.go
+++ b/testing/releases/latest.go
@@ -3,7 +3,6 @@ package releases
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"runtime"
 	"time"
 
@@ -62,7 +61,7 @@ func DownloadLatest(ctx context.Context, conf DownloadConfig) (string, error) {
 		conf.Dir = "../bin"
 	}
 
-	dl, err := download.NewDownloader(time.Minute, filepath.Join(conf.Dir, conf.Which))
+	dl, err := download.NewDownloader(time.Minute, conf.Dir)
 	if err != nil {
 		return "", fmt.Errorf("download failed: %w", err)
 	}

--- a/testing/releases/latest_test.go
+++ b/testing/releases/latest_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -54,6 +55,9 @@ func TestDownloadLatest(t *testing.T) {
 			Dir:     dir,
 		})
 		assert.Assert(t, err)
+
+		// Check that we don't double up the which path
+		assert.Check(t, !strings.Contains(path, "my-app/my-app"))
 
 		b, err := os.ReadFile(path) //nolint:gosec // it's a test file we just created
 		assert.Assert(t, err)


### PR DESCRIPTION
Without this we ends up creating cache folders like:
`base/which/which/version-1.1/os/arch/`
which should be:
`base/which/version-1.1/os/arch/`