### PR TITLE
Add `-s -w` ldflags by default to all compiled plugin binaries

### DIFF
--- a/plugin/releaser/releaser.go
+++ b/plugin/releaser/releaser.go
@@ -114,6 +114,7 @@ func (r Releaser) Run(ctx context.Context, opts Opts) error {
 func (r Releaser) build(ctx context.Context, source, workingDir string) (func(), error) {
 	comp := compiler.New(compiler.Config{
 		BaseDir: r.buildDir,
+		LDFlags: "-s -w", // remove debug information from released binaries
 	})
 
 	cleanup := func() {


### PR DESCRIPTION
shrinks the oidc plugin binary from ~`21M` to ~`16M` locally as an anecdotal data point