### PR TITLE
Move from http.Client to httpclient.Client for retry goodies

### DIFF
--- a/releases/download/downloader.go
+++ b/releases/download/downloader.go
@@ -4,22 +4,23 @@ Package download helps download releases of binaries.
 package download
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/circleci/ex/closer"
+	"github.com/circleci/ex/httpclient"
 )
 
 type Downloader struct {
 	dir    string
-	client http.Client
+	client *httpclient.Client
 }
 
 func NewDownloader(timeout time.Duration, dir string) (*Downloader, error) {
@@ -35,9 +36,9 @@ func NewDownloader(timeout time.Duration, dir string) (*Downloader, error) {
 
 	return &Downloader{
 		dir: dir,
-		client: http.Client{
+		client: httpclient.New(httpclient.Config{
 			Timeout: timeout,
-		},
+		}),
 	}, nil
 }
 
@@ -124,23 +125,13 @@ func (d *Downloader) downloadFile(ctx context.Context, url, target string, perm 
 	}
 	defer closer.ErrorHandler(out, &err)
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("cannot create HTTP request: %w", err)
-	}
-
-	//nolint:bodyclose // handled by closer
-	res, err := d.client.Do(req)
+	var resp []byte
+	err = d.client.Call(ctx, httpclient.NewRequest("GET", url, httpclient.BytesDecoder(&resp)))
 	if err != nil {
 		return fmt.Errorf("could not get URL %q: %w", url, err)
 	}
-	defer closer.ErrorHandler(res.Body, &err)
 
-	if res.StatusCode >= 300 {
-		return fmt.Errorf("unexpected status: %s", res.Status)
-	}
-
-	_, err = io.Copy(out, res.Body)
+	_, err = io.Copy(out, bytes.NewBuffer(resp))
 	if err != nil {
 		return fmt.Errorf("could not write file %q: %w", target, err)
 	}

--- a/releases/download/downloader_test.go
+++ b/releases/download/downloader_test.go
@@ -144,7 +144,7 @@ func TestDownloader_Download(t *testing.T) {
 
 	t.Run("Not found", func(t *testing.T) {
 		target, err := d.Download(ctx, server.URL+"/test/file-3.txt", 0644)
-		assert.Check(t, cmp.ErrorContains(err, "unexpected status"))
+		assert.Check(t, cmp.ErrorContains(err, "was 404 (Not Found)"))
 		assert.Check(t, cmp.Equal(target, ""))
 
 		requests := recorder.FindRequests("GET", url.URL{Path: "/test/file-3.txt"})


### PR DESCRIPTION
Leverage the `httpclient.Client` to allow for automatic retries within the timeout window