### PR TITLE
[EXEC-3010] http.Client -> httpclient.Client for release downloader (again)

### DIFF
--- a/releases/download/downloader.go
+++ b/releases/download/downloader.go
@@ -126,7 +126,9 @@ func (d *Downloader) downloadFile(ctx context.Context, url, target string, perm 
 	defer closer.ErrorHandler(out, &err)
 
 	var resp []byte
-	err = d.client.Call(ctx, httpclient.NewRequest("GET", url, httpclient.BytesDecoder(&resp)))
+	err = d.client.Call(ctx, httpclient.NewRequest("GET", url,
+		httpclient.Timeout(30*time.Second),
+		httpclient.BytesDecoder(&resp)))
 
 	if err != nil {
 		return fmt.Errorf("could not get URL %q: %w", url, err)

--- a/releases/download/downloader.go
+++ b/releases/download/downloader.go
@@ -4,22 +4,23 @@ Package download helps download releases of binaries.
 package download
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/circleci/ex/closer"
+	"github.com/circleci/ex/httpclient"
 )
 
 type Downloader struct {
 	dir    string
-	client http.Client
+	client *httpclient.Client
 }
 
 func NewDownloader(timeout time.Duration, dir string) (*Downloader, error) {
@@ -35,9 +36,9 @@ func NewDownloader(timeout time.Duration, dir string) (*Downloader, error) {
 
 	return &Downloader{
 		dir: dir,
-		client: http.Client{
+		client: httpclient.New(httpclient.Config{
 			Timeout: timeout,
-		},
+		}),
 	}, nil
 }
 
@@ -124,23 +125,14 @@ func (d *Downloader) downloadFile(ctx context.Context, url, target string, perm 
 	}
 	defer closer.ErrorHandler(out, &err)
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("cannot create HTTP request: %w", err)
-	}
+	var resp []byte
+	err = d.client.Call(ctx, httpclient.NewRequest("GET", url, httpclient.BytesDecoder(&resp)))
 
-	//nolint:bodyclose // handled by closer
-	res, err := d.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("could not get URL %q: %w", url, err)
 	}
-	defer closer.ErrorHandler(res.Body, &err)
 
-	if res.StatusCode >= 300 {
-		return fmt.Errorf("unexpected status: %s", res.Status)
-	}
-
-	_, err = io.Copy(out, res.Body)
+	_, err = io.Copy(out, bytes.NewBuffer(resp))
 	if err != nil {
 		return fmt.Errorf("could not write file %q: %w", target, err)
 	}

--- a/releases/download/downloader_test.go
+++ b/releases/download/downloader_test.go
@@ -2,7 +2,6 @@ package download
 
 import (
 	"compress/gzip"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,10 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 
 	"github.com/circleci/ex/testing/httprecorder"
+	"github.com/circleci/ex/testing/testcontext"
 )
 
 func TestDownloader_Download(t *testing.T) {
@@ -51,7 +52,7 @@ func TestDownloader_Download(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx := context.Background()
+	ctx := testcontext.Background()
 
 	dir, err := os.MkdirTemp("", "e2e-test")
 	assert.Assert(t, err)
@@ -79,7 +80,7 @@ func TestDownloader_Download(t *testing.T) {
 				"User-Agent":      {"Go-http-client/1.1"},
 			},
 			Body: []byte(""),
-		}})
+		}}, ignoreHoneyCombHeader)
 	})
 
 	url2 := server.URL + "/test/file-2.txt"
@@ -100,7 +101,7 @@ func TestDownloader_Download(t *testing.T) {
 				"User-Agent":      {"Go-http-client/1.1"},
 			},
 			Body: []byte(""),
-		}})
+		}}, ignoreHoneyCombHeader)
 	})
 
 	t.Run("Cached download", func(t *testing.T) {
@@ -112,7 +113,7 @@ func TestDownloader_Download(t *testing.T) {
 		assert.Check(t, strings.HasSuffix(target, filepath.Join("test", "file-2.txt")))
 		assertFileContents(t, target, "Second compressed file")
 
-		assert.DeepEqual(t, recorder.AllRequests(), originalRequests)
+		assert.DeepEqual(t, recorder.AllRequests(), originalRequests, ignoreHoneyCombHeader)
 	})
 
 	t.Run("Remove cached and re-download", func(t *testing.T) {
@@ -139,7 +140,7 @@ func TestDownloader_Download(t *testing.T) {
 				"User-Agent":      {"Go-http-client/1.1"},
 			},
 			Body: []byte(""),
-		}})
+		}}, ignoreHoneyCombHeader)
 	})
 
 	t.Run("Not found", func(t *testing.T) {
@@ -156,7 +157,23 @@ func TestDownloader_Download(t *testing.T) {
 				"User-Agent":      {"Go-http-client/1.1"},
 			},
 			Body: []byte(""),
-		}})
+		}}, ignoreHoneyCombHeader)
+	})
+
+	t.Run("remote downloads", func(t *testing.T) {
+		urls := []string{
+			"https://circleci-binary-releases.s3.amazonaws.com/distributor/1.0.121921-7112fcb8/darwin/amd64/execution.e2e.test",
+			"https://circleci-binary-releases.s3.amazonaws.com/output/1.0.17772-56764d3/linux/amd64/receiver",
+		}
+		for _, remoteURL := range urls {
+			target, err := d.Download(ctx, remoteURL, 0644)
+			assert.NilError(t, err)
+
+			fi, err := os.Stat(target)
+			assert.NilError(t, err)
+
+			assert.Check(t, fi.Size() > 0)
+		}
 	})
 }
 
@@ -176,3 +193,7 @@ func assertFileContents(t *testing.T, path, contents string) {
 
 	assert.Check(t, cmp.Equal(string(b), contents))
 }
+
+var ignoreHoneyCombHeader = cmpopts.IgnoreMapEntries(func(key string, values []string) bool {
+	return key == "X-Honeycomb-Trace"
+})

--- a/releases/download/downloader_test.go
+++ b/releases/download/downloader_test.go
@@ -144,7 +144,7 @@ func TestDownloader_Download(t *testing.T) {
 
 	t.Run("Not found", func(t *testing.T) {
 		target, err := d.Download(ctx, server.URL+"/test/file-3.txt", 0644)
-		assert.Check(t, cmp.ErrorContains(err, "unexpected status"))
+		assert.Check(t, cmp.ErrorContains(err, "was 404 (Not Found)"))
 		assert.Check(t, cmp.Equal(target, ""))
 
 		requests := recorder.FindRequests("GET", url.URL{Path: "/test/file-3.txt"})


### PR DESCRIPTION
It seems the build-agent e2e tests often tripped the default 5 second request + decode timeout when grabbing the output binaries to setup the harnesses. 

This PR re-introduces the adoption of `httpclient.Client` in the ex downloader, and also adds a 30 second per-request timeout to avoid using the lower default value. This was tested by pinning ex to a commit-hash version from this branch [here](https://app.circleci.com/pipelines/github/circleci/build-agent/13302/workflows/6d91b455-1139-4780-a701-65708da7964e).