### PR TITLE
[EXEC-3120] Allow non-mandatory messages to be published

### DIFF
--- a/rabbit/publisherpool.go
+++ b/rabbit/publisherpool.go
@@ -54,6 +54,7 @@ func NewPublisherPool(ctx context.Context, name string, dialer *amqpextra.Dialer
 	}
 }
 
+// Close frees the resources of the PublisherPool
 func (p *PublisherPool) Close(ctx context.Context) (err error) {
 	ctx, span := o11y.StartSpan(ctx, "pool: close")
 	defer o11y.End(span, &err)
@@ -62,7 +63,25 @@ func (p *PublisherPool) Close(ctx context.Context) (err error) {
 	return nil
 }
 
+// Publish allows the publication of a message with mandatory routing.
+// This should be your preferred option over PublishOptional
 func (p *PublisherPool) Publish(ctx context.Context, msg publisher.Message) (err error) {
+	ctx, span := o11y.StartSpan(ctx, "pool: publish")
+	defer o11y.End(span, &err)
+	span.AddField("exchange", msg.Exchange)
+	span.AddField("key", msg.Key)
+	span.AddField("content_type", msg.Publishing.ContentType)
+
+	span.RecordMetric(o11y.Timing("pool.publish", "exchange", "key", "content_type"))
+
+	return p.publishMandatory(ctx, msg)
+}
+
+// PublishOptional allows the publication of a message without mandatory routing.
+// This is useful when the message is not already being consumed.
+// _You should prefer Publish, which has mandatory routing forced, and should_
+// _move to mandatory routing once you confirm your message is indeed consumed._
+func (p *PublisherPool) PublishOptional(ctx context.Context, msg publisher.Message) (err error) {
 	ctx, span := o11y.StartSpan(ctx, "pool: publish")
 	defer o11y.End(span, &err)
 	span.AddField("exchange", msg.Exchange)
@@ -74,9 +93,34 @@ func (p *PublisherPool) Publish(ctx context.Context, msg publisher.Message) (err
 	return p.publish(ctx, msg)
 }
 
+// JSON contains the MIME content type for a JSON payload.
 const JSON = "application/json; charset=utf-8"
 
+// PublishJSON allows the publication of a JSON message with mandatory routing.
+// This should be your preferred option over PublishJSONOptional
 func (p *PublisherPool) PublishJSON(ctx context.Context, msg publisher.Message, v interface{}) (err error) {
+	ctx, span := o11y.StartSpan(ctx, "pool: publish_json")
+	defer o11y.End(span, &err)
+	span.AddField("exchange", msg.Exchange)
+	span.AddField("key", msg.Key)
+	span.AddField("content_type", JSON)
+
+	span.RecordMetric(o11y.Timing("pool.publish", "exchange", "key", "content_type"))
+
+	msg.Publishing.ContentType = JSON
+	msg.Publishing.Body, err = json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	return p.publishMandatory(ctx, msg)
+}
+
+// PublishJSONOptional allows the publication of a message without mandatory routing.
+// This is useful when the message is not already being consumed.
+// _You should prefer PublishJSON, which has mandatory routing forced, and should_
+// _move to mandatory routing once you confirm your message is indeed consumed._
+func (p *PublisherPool) PublishJSONOptional(ctx context.Context, msg publisher.Message, v interface{}) (err error) {
 	ctx, span := o11y.StartSpan(ctx, "pool: publish_json")
 	defer o11y.End(span, &err)
 	span.AddField("exchange", msg.Exchange)
@@ -94,8 +138,12 @@ func (p *PublisherPool) PublishJSON(ctx context.Context, msg publisher.Message, 
 	return p.publish(ctx, msg)
 }
 
-func (p *PublisherPool) publish(ctx context.Context, msg publisher.Message) error {
+func (p *PublisherPool) publishMandatory(ctx context.Context, msg publisher.Message) error {
 	msg.Mandatory = true
+	return p.publish(ctx, msg)
+}
+
+func (p *PublisherPool) publish(ctx context.Context, msg publisher.Message) error {
 	msg.Context = ctx
 
 	obj, err := p.pool.BorrowObject(ctx)
@@ -114,10 +162,12 @@ func (p *PublisherPool) publish(ctx context.Context, msg publisher.Message) erro
 	return pub.Publish(msg)
 }
 
+// MetricName returns the name of the PublisherPool
 func (p *PublisherPool) MetricName() string {
 	return p.name
 }
 
+// Gauges returns internal measures of the health of the PublisherPool
 func (p *PublisherPool) Gauges(_ context.Context) map[string]float64 {
 	return map[string]float64{
 		"active":    float64(p.pool.GetNumActive()),

--- a/rabbit/publisherpool_test.go
+++ b/rabbit/publisherpool_test.go
@@ -158,6 +158,26 @@ func TestPublisherPool_MandatoryRouting(t *testing.T) {
 		assert.Check(t, cmp.Contains(s, "result=error"))
 	})
 }
+func TestPublisherPool_OptionalRouting(t *testing.T) {
+	var buf syncbuffer.SyncBuffer
+	ctx := o11y.WithProvider(context.Background(), honeycomb.New(honeycomb.Config{
+		Format: "text",
+		Writer: &buf,
+	}))
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	t.Cleanup(cancel)
+
+	u := rabbitfixture.New(ctx, t)
+	pool := createPool(ctx, t, u)
+
+	t.Run("Check sending does not fail", func(t *testing.T) {
+		err := pool.PublishOptional(ctx,
+			publisher.Message{Key: "does not exist"},
+		)
+		assert.Equal(t, err, nil)
+	})
+}
 
 func TestPublisherPool_Publish_LoadTest(t *testing.T) {
 	// Use non-o11y context to keep test logs clear


### PR DESCRIPTION
This should allow messages to be posted even though no exchanges exist. Optional messages allow us to start emitting messages even though nobody listens for them yet, which allows people to start working with the new messages before we make them mandatory.

Definitely the "mandatory" should happen afterwards, but for now it allows us to be less dependant on when a team is ready to start listening for messages before we deliver those.