### PR TITLE
Correct documentation

### DIFF
--- a/o11y/o11y.go
+++ b/o11y/o11y.go
@@ -202,7 +202,8 @@ func WithProvider(ctx context.Context, p Provider) context.Context {
 	return context.WithValue(ctx, providerKey{}, p)
 }
 
-// FromContext returns the provider stored in the context, or nil if none exists.
+// FromContext returns the provider stored in the context, or the default noop
+// provider if none exists.
 func FromContext(ctx context.Context) Provider {
 	provider, ok := ctx.Value(providerKey{}).(Provider)
 	if !ok {


### PR DESCRIPTION
The documentation for FromContext mistakenly used to say that it returns nil if the provider isn't found in the context, where in fact it returns a no-op provider instead.