### PR TITLE
M1 macs seem to support versioning

### DIFF
--- a/testing/miniofixture/miniofixture_test.go
+++ b/testing/miniofixture/miniofixture_test.go
@@ -29,7 +29,7 @@ func TestSetup(t *testing.T) {
 		t.Run("maybe-is-not-versioned", func(t *testing.T) {
 			// something about the file system on mac means that only one volume means that
 			// versioning can not be enabled
-			if runtime.GOOS == "darwin" {
+			if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
 				assert.Check(t, !fix.Versioned)
 			} else {
 				// on other os's the file system appears to support versioning with one volume
@@ -40,13 +40,14 @@ func TestSetup(t *testing.T) {
 		})
 
 		t.Run("force-ver-fails", func(t *testing.T) {
-			if runtime.GOOS != "darwin" {
-				t.Skip("force versioning succeeds on non-mac file systems")
+			if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
+				fix.Client = nil
+				fix.ForceVersioned = true
+				err := runSetup(ctx, fix)
+				assert.ErrorContains(t, err, "failed")
+			} else {
+				t.Skip("force versioning succeeds on non-intel-mac file systems")
 			}
-			fix.Client = nil
-			fix.ForceVersioned = true
-			err := runSetup(ctx, fix)
-			assert.ErrorContains(t, err, "failed")
 		})
 	})
 


### PR DESCRIPTION
The Minio test fixture tests were failing for me locally, while debugging I found some special logic put in for macs since they didn't support filesystem versioning, and in my case the tests were failing because the M1 macs do seem to support the filesystem versioning. 

I added an escape hatch for the arm64 macs 