### PR TITLE
Otel - set the honeycomb dataset in the grpc headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
+	go.opentelemetry.io/proto/otlp v1.1.0
 	golang.org/x/net v0.20.0
 	golang.org/x/sync v0.6.0
 	google.golang.org/grpc v1.61.0
@@ -114,7 +115,6 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
-	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect

--- a/o11y/otel/config.go
+++ b/o11y/otel/config.go
@@ -5,5 +5,6 @@ import o11yconf "github.com/circleci/ex/config/o11y"
 type Config struct {
 	o11yconf.Config
 
+	OtelDataset     string
 	GrpcHostAndPort string
 }

--- a/o11y/otel/otel.go
+++ b/o11y/otel/otel.go
@@ -39,7 +39,7 @@ func New(conf Config) (o11y.Provider, error) {
 		return nil, err
 	}
 	if conf.GrpcHostAndPort != "" {
-		grpc, err := newGRPC(context.Background(), conf.GrpcHostAndPort)
+		grpc, err := newGRPC(context.Background(), conf.GrpcHostAndPort, conf.OtelDataset)
 		if err != nil {
 			return nil, err
 		}
@@ -84,10 +84,11 @@ func New(conf Config) (o11y.Provider, error) {
 	}, nil
 }
 
-func newGRPC(ctx context.Context, endpoint string) (*otlptrace.Exporter, error) {
+func newGRPC(ctx context.Context, endpoint, dataset string) (*otlptrace.Exporter, error) {
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(endpoint),
 		otlptracegrpc.WithInsecure(),
+		otlptracegrpc.WithHeaders(map[string]string{"x-honeycomb-dataset": dataset}),
 	}
 	return otlptrace.New(ctx, otlptracegrpc.NewClient(opts...))
 }


### PR DESCRIPTION
Sets the custom header that the collectors use to direct to the correct dataset (this fooked us up in the past)

Adds a otel gRPC server to assert that the header is received. 