### PR TITLE
Move the `x-honeycomb-dataset` attribute to the tracer provider

### DIFF
--- a/o11y/otel/otel.go
+++ b/o11y/otel/otel.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
@@ -54,11 +55,10 @@ func New(conf Config) (o11y.Provider, error) {
 		semconv.SchemaURL,
 		semconv.ServiceNameKey.String(conf.Service),
 		semconv.ServiceVersionKey.String(conf.Version),
+		// This custom attribute is used by our honeycomb otel collector to route these traces
+		// to the correct dataset.
+		attribute.String("x-honeycomb-dataset", conf.Dataset),
 	)
-
-	// This custom attribute is used by our honeycomb otel collector to route these traces
-	// to the correct dataset.
-	globalFields.addField("x-honeycomb-dataset", conf.Dataset)
 
 	bsp := sdktrace.NewBatchSpanProcessor(exporter)
 	tp := sdktrace.NewTracerProvider(

--- a/o11y/otel/otel_test.go
+++ b/o11y/otel/otel_test.go
@@ -72,8 +72,6 @@ func TestO11y(t *testing.T) {
 
 	spanNames := map[string]bool{}
 	for _, s := range spans {
-		// jaeger normalises certain tags into the process entry
-		assertTag(t, s.Tags, "x-honeycomb-dataset", "local-testing")
 		if s.OperationName == "root" {
 			assertTag(t, s.Tags, "raw_got", uuid)
 		}
@@ -289,7 +287,8 @@ func TestRealCollector_HoneycombDatasetHeader(t *testing.T) {
 
 		span0 := col.Spans()[0]
 		assert.Check(t, cmp.Equal(span0.Name, "roobar"))
-		assert.Check(t, cmp.Equal(span0.Attrs["x-honeycomb-dataset"], "execyooshun"))
+		// We don't get span-level attributes for dataset - OTel sends it as collector metadata instead
+		assert.Check(t, cmp.Contains(col.metadata["x-honeycomb-dataset"], "execyooshun"))
 	})
 }
 


### PR DESCRIPTION
After a successful programmatic verification from the company Slack.