### PR TITLE
Add the X-Route header

### DIFF
--- a/o11y/wrappers/o11ygin/o11ygin.go
+++ b/o11y/wrappers/o11ygin/o11ygin.go
@@ -51,6 +51,15 @@ func Middleware(provider o11y.Provider, serverName string, queryParams map[strin
 			}
 		}
 
+		// Extract the route from the engine and put it into an X-Route header on the response.
+		// this is similar to what's already being done in circle/circle, and backplane-go
+		// https://github.com/circleci/circle/blob/756e1245d1f00ba37b5c0e9531e616eae3073b06/src/circle/http/defpage.clj#L35
+		route := c.FullPath()
+		if route == "" {
+			route = "not-found"
+		}
+		c.Header("X-Route", route)
+
 		// Server OTEL attributes
 		span.AddRawField("meta.type", "http_server")
 		span.AddRawField("http.server_name", serverName)

--- a/o11y/wrappers/o11ygin/o11ygin_test.go
+++ b/o11y/wrappers/o11ygin/o11ygin_test.go
@@ -181,6 +181,9 @@ func TestMiddleware(t *testing.T) {
 	t.Run("Hit an ID that exists", func(t *testing.T) {
 		err = client.Call(ctx, httpclient.NewRequest("POST", "/api/%s",
 			httpclient.RouteParams("exists"),
+			httpclient.ResponseHeader(func(hdr http.Header) {
+				assert.Check(t, cmp.Equal(hdr.Get("X-Route"), "/api/:id"))
+			}),
 		))
 		assert.Assert(t, err)
 	})


### PR DESCRIPTION
This header can then be inspected by the API gateway and added to telemetry for better segmentation.