### PR TITLE
Makes sure a propagated otel span is added to the context

### DIFF
--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -45,6 +45,8 @@ func TestClient_Call_Propagates(t *testing.T) {
 			helpers := o11y.FromContext(ctx).Helpers()
 			traceID, _ := helpers.TraceIDs(r.Context())
 			traceIDChan <- traceID
+			span := o11y.FromContext(r.Context()).GetSpan(r.Context())
+			span.AddField("prov_get_span", true)
 		})
 
 		server := httptest.NewServer(o11ynethttp.Middleware(o11y.FromContext(ctx), "name", okHandler))
@@ -84,6 +86,8 @@ func TestClient_Call_Propagates(t *testing.T) {
 			helpers := op.Helpers()
 			traceID, _ := helpers.TraceIDs(r.Context())
 			traceIDChan <- traceID
+			span := o11y.FromContext(r.Context()).GetSpan(r.Context())
+			span.AddField("prov_get_span", true)
 		})
 
 		server := httptest.NewServer(o11ynethttp.Middleware(op, "name", okHandler))
@@ -114,6 +118,8 @@ func TestClient_Call_Propagates(t *testing.T) {
 			helpers := srvProvider.Helpers()
 			traceID, _ := helpers.TraceIDs(r.Context())
 			traceIDChan <- traceID
+			span := o11y.FromContext(r.Context()).GetSpan(r.Context())
+			span.AddField("prov_get_span", true)
 		})
 
 		server := httptest.NewServer(o11ynethttp.Middleware(srvProvider, "name", okHandler))
@@ -149,6 +155,8 @@ func TestClient_Call_Propagates(t *testing.T) {
 			helpers := srvProvider.Helpers()
 			traceID, _ := helpers.TraceIDs(r.Context())
 			traceIDChan <- traceID
+			span := o11y.FromContext(r.Context()).GetSpan(r.Context())
+			span.AddField("prov_get_span", true)
 		})
 
 		server := httptest.NewServer(o11ynethttp.Middleware(srvProvider, "name", okHandler))

--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -324,6 +324,7 @@ func (h *honeycomb) StartSpan(ctx context.Context, name string) (context.Context
 	return ctx, WrapSpan(newSpan)
 }
 
+// GetSpan returns the active span in the given context. It will return nil if there is no span available.
 func (h *honeycomb) GetSpan(ctx context.Context) o11y.Span {
 	return WrapSpan(trace.GetSpanFromContext(ctx))
 }

--- a/o11y/o11y.go
+++ b/o11y/o11y.go
@@ -34,7 +34,7 @@ type Provider interface {
 	//   defer span.End()
 	StartSpan(ctx context.Context, name string) (context.Context, Span)
 
-	// GetSpan returns the currently active span
+	// GetSpan returns the active span in the given context. It will return nil if there is no span available.
 	GetSpan(ctx context.Context) Span
 
 	// AddField is for adding application-level information to the currently active span

--- a/o11y/otel/otel.go
+++ b/o11y/otel/otel.go
@@ -121,6 +121,7 @@ func (o OTel) StartSpan(ctx context.Context, name string) (context.Context, o11y
 	return ctx, s
 }
 
+// GetSpan returns the active span in the given context. It will return nil if there is no span available.
 func (o OTel) GetSpan(ctx context.Context) o11y.Span {
 	if s, ok := ctx.Value(spanCtxKey).(*span); ok {
 		return s

--- a/o11y/wrappers/o11ynethttp/o11ynethttp.go
+++ b/o11y/wrappers/o11ynethttp/o11ynethttp.go
@@ -31,6 +31,7 @@ func Middleware(provider o11y.Provider, name string, handler http.Handler) http.
 		ctx = o11y.WithProvider(ctx, provider)
 		ctx = o11y.WithBaggage(ctx, baggage.Get(ctx, r))
 		ctx = context.WithValue(ctx, nethttpRouteRecorderContextKey{}, routeRecorder)
+
 		r = r.WithContext(ctx)
 
 		// We default to using the Path as the name and route - which could be high cardinality


### PR DESCRIPTION
As flushed out by testing on a crashing feature-flags !

GetSpan returns nil if there is not span in the current context, and otel propagation was not injecting it.

