### PR TITLE
Disable w3c propagation [FND-26]

### DIFF
--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -111,6 +111,8 @@ func TestClient_Call_Propagates(t *testing.T) {
 	})
 
 	t.Run("hc server accepts otel client propagation", func(t *testing.T) {
+		t.Skip("TODO - disabled whilst we test the propagation / sampling interplay")
+
 		srvCtx := testcontext.Background()
 		srvProvider := o11y.FromContext(srvCtx)
 
@@ -148,6 +150,8 @@ func TestClient_Call_Propagates(t *testing.T) {
 	})
 
 	t.Run("hc client propagates to otel server", func(t *testing.T) {
+		t.Skip("TODO - disabled whilst we test the propagation / sampling interplay")
+
 		srvProvider, err := otel.New(otel.Config{})
 		assert.NilError(t, err)
 

--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -376,12 +376,13 @@ func (h helpers) ExtractPropagation(ctx context.Context) o11y.PropagationContext
 		propagation.TracePropagationHTTPHeader: []string{parent},
 	}
 
+	// TODO - make optional
 	// Start sending wc3 headers as well as honeycomb headers
-	_, otelHeaders := propagation.MarshalW3CTraceContext(ctx, s.PropagationContext())
-
-	for k, v := range otelHeaders {
-		headers.Set(k, v)
-	}
+	// _, otelHeaders := propagation.MarshalW3CTraceContext(ctx, s.PropagationContext())
+	//
+	// for k, v := range otelHeaders {
+	//	headers.Set(k, v)
+	// }
 
 	return o11y.PropagationContext{
 		Parent:  parent,
@@ -399,11 +400,14 @@ func (h helpers) InjectPropagation(ctx context.Context, p o11y.PropagationContex
 	// Use the honeycomb propagation if present, otherwise grab the w3c headers
 	if field != "" {
 		prop, _ = propagation.UnmarshalHoneycombTraceContext(field)
-	} else {
-		_, prop, _ = propagation.UnmarshalW3CTraceContext(ctx, map[string]string{
-			propagation.TraceparentHeader: p.Headers.Get(propagation.TraceparentHeader),
-		})
 	}
+	// TODO - make optional
+	// else {
+	// _, prop, _ = propagation.UnmarshalW3CTraceContext(ctx, map[string]string{
+	// propagation.TraceparentHeader: p.Headers.Get(propagation.TraceparentHeader),
+	// })
+	// }
+	// }
 
 	ctx, tr := trace.NewTrace(ctx, prop)
 	return ctx, WrapSpan(tr.GetRootSpan())


### PR DESCRIPTION
This looks to be causing lots of 'late' sampled in events from refinery