### PR TITLE
Add an option to disable w3c trace header propagation

### DIFF
--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -111,8 +111,6 @@ func TestClient_Call_Propagates(t *testing.T) {
 	})
 
 	t.Run("hc server accepts otel client propagation", func(t *testing.T) {
-		t.Skip("TODO - disabled whilst we test the propagation / sampling interplay")
-
 		srvCtx := testcontext.Background()
 		srvProvider := o11y.FromContext(srvCtx)
 
@@ -150,8 +148,6 @@ func TestClient_Call_Propagates(t *testing.T) {
 	})
 
 	t.Run("hc client propagates to otel server", func(t *testing.T) {
-		t.Skip("TODO - disabled whilst we test the propagation / sampling interplay")
-
 		srvProvider, err := otel.New(otel.Config{})
 		assert.NilError(t, err)
 
@@ -184,6 +180,42 @@ func TestClient_Call_Propagates(t *testing.T) {
 
 		t.Logf("httpClientTraceID: %q", httpClientTraceID)
 		assert.Check(t, cmp.Equal(httpClientTraceID, <-traceIDChan))
+	})
+
+	t.Run("hc client w3c disabled", func(t *testing.T) {
+		srvProvider, err := otel.New(otel.Config{})
+		assert.NilError(t, err)
+
+		okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			helpers := srvProvider.Helpers()
+			traceID, _ := helpers.TraceIDs(r.Context())
+			traceIDChan <- traceID
+			span := o11y.FromContext(r.Context()).GetSpan(r.Context())
+			span.AddField("prov_get_span", true)
+		})
+
+		server := httptest.NewServer(o11ynethttp.Middleware(srvProvider, "name", okHandler))
+		client := httpclient.New(httpclient.Config{
+			Name:                       "otel-test",
+			BaseURL:                    server.URL,
+			Timeout:                    time.Second,
+			DisableW3CTracePropagation: true,
+		})
+
+		// Client Side stuff
+		ctx := testcontext.Background()
+		op := o11y.FromContext(ctx)
+		helpers := op.Helpers()
+
+		ctx, span := o11y.StartSpan(ctx, "new client span")
+		err = client.Call(ctx, httpclient.NewRequest("POST", "/"))
+		assert.Check(t, err)
+		span.End()
+
+		httpClientTraceID, _ := helpers.TraceIDs(ctx)
+
+		// The server trace id should be different from the client one
+		assert.Check(t, httpClientTraceID != <-traceIDChan)
 	})
 }
 

--- a/o11y/o11y.go
+++ b/o11y/o11y.go
@@ -57,8 +57,8 @@ type Provider interface {
 	// MetricsProvider grants lower control over the metrics that o11y sends, allowing skipping spans.
 	MetricsProvider() MetricsProvider
 
-	// Helpers returns some specific helper functions
-	Helpers() Helpers
+	// Helpers returns some specific helper functions. Temporary optional param during the cutover to otel
+	Helpers(disableW3c ...bool) Helpers
 }
 
 // PropagationContext contains trace context values that are propagated from service to service.
@@ -340,7 +340,7 @@ func (c *noopProvider) MetricsProvider() MetricsProvider {
 	return &statsd.NoOpClient{}
 }
 
-func (c *noopProvider) Helpers() Helpers {
+func (c *noopProvider) Helpers(...bool) Helpers {
 	return noopHelpers{}
 }
 

--- a/o11y/otel/otel.go
+++ b/o11y/otel/otel.go
@@ -177,8 +177,16 @@ func (o OTel) MetricsProvider() o11y.MetricsProvider {
 	return o.metricsProvider
 }
 
-func (o OTel) Helpers() o11y.Helpers {
-	return helpers{p: o}
+func (o OTel) Helpers(disableW3c ...bool) o11y.Helpers {
+	d := false
+	if len(disableW3c) > 0 {
+		d = disableW3c[0]
+	}
+
+	return helpers{
+		p:          o,
+		disableW3c: d,
+	}
 }
 
 func (o OTel) wrapSpan(s trace.Span) *span {


### PR DESCRIPTION
The option is only settable on the http client since this appears to be causing all the propagation actoss dataset sampling problem.