### PR TITLE
Allow some services to disable text logging of spans.

### DIFF
--- a/config/o11y/otel.go
+++ b/config/o11y/otel.go
@@ -22,6 +22,8 @@ type OtelConfig struct {
 	GrpcHostAndPort string
 	Dataset         string
 
+	DisableText bool
+
 	SampleTraces  bool
 	SampleKeyFunc func(map[string]interface{}) string
 	SampleRates   map[string]uint
@@ -63,6 +65,8 @@ func Otel(ctx context.Context, o OtelConfig) (context.Context, func(context.Cont
 			attribute.String("mode", o.Mode),
 			attribute.String("version", o.Version),
 		},
+
+		DisableText: o.DisableText,
 
 		SampleTraces:  o.SampleTraces,
 		SampleKeyFunc: o.SampleKeyFunc,


### PR DESCRIPTION
E.g when we tool up high throughput services for otel - i think we might overwhelm logging if we do text 

ex honeycomb - never logged spans - because we believed in tracing

the otel stuff started dumping to stdout - kind of in preparation for heavy server side sampling, but we do need to disable text logged spans