### PR TITLE
Add the option to flatten otel spans

### DIFF
--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -469,6 +469,10 @@ func (s *span) End() {
 	s.span.Send()
 }
 
+func (s *span) Flatten(string) {
+	// N.B. We are not implementing this feature in hc
+}
+
 func mustValidateKey(key string) {
 	if strings.Contains(key, "-") {
 		panic(fmt.Errorf("key %q cannot contain '-'", key))

--- a/testing/jaeger/client.go
+++ b/testing/jaeger/client.go
@@ -1,0 +1,82 @@
+package jaeger
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	hc "github.com/circleci/ex/httpclient"
+)
+
+func New(base, service string) Client {
+	return Client{
+		cl: hc.New(hc.Config{
+			Name:    "jaeger-api",
+			BaseURL: base + "/api",
+		}),
+		service: service,
+	}
+}
+
+type Client struct {
+	cl      *hc.Client
+	service string
+}
+
+type Tag struct {
+	Key   string `json:"key"`
+	Type  string `json:"type"`
+	Value any    `json:"value"`
+}
+
+type Span struct {
+	TraceID       string `json:"traceID"`
+	SpanID        string `json:"spanID"`
+	OperationName string `json:"operationName"`
+	References    []struct {
+		RefType string `json:"refType"`
+		TraceID string `json:"traceID"`
+		SpanID  string `json:"spanID"`
+	} `json:"references"`
+	StartTime int64  `json:"startTime"`
+	Duration  int    `json:"duration"`
+	Tags      []Tag  `json:"tags"`
+	Logs      []any  `json:"logs"`
+	ProcessID string `json:"processID"`
+	Warnings  any    `json:"warnings"`
+}
+
+type Process struct {
+	ServiceName string `json:"service_name"`
+	Tags        []Tag  `json:"tags"`
+}
+
+type Trace struct {
+	ID        string             `json:"id"`
+	Spans     []Span             `json:"spans"`
+	Processes map[string]Process `json:"processes"`
+}
+
+func (j *Client) Traces(ctx context.Context, since time.Time) ([]Trace, error) {
+	resp := struct {
+		Data []Trace `json:"data"`
+	}{}
+	err := j.cl.Call(ctx, hc.NewRequest("GET", "/traces",
+		hc.QueryParam("service", j.service),
+		hc.QueryParam("start", strconv.FormatInt(since.UnixMicro(), 10)),
+		hc.JSONDecoder(&resp),
+	))
+	return resp.Data, err
+}
+
+func AssertTag(t *testing.T, tags []Tag, k, v string) {
+	t.Helper()
+	for _, tag := range tags {
+		if tag.Key == k && fmt.Sprintf("%v", tag.Value) == v {
+			return
+		}
+	}
+	t.Errorf("key:%q with value %q was not found", k, v)
+}


### PR DESCRIPTION
Marking a span as flattened - will roll up any attributes into the parent span. each child from a flattened span will be considered flattened.

If the httpcl request is flattened then all server spans will be considered flattened, but they will not pas back the flattened fields to the client. Essentially this will cause ALL server side spans to be dropped. 