### PR TITLE
Check attribute value interfaces for held nil values

### DIFF
--- a/o11y/otel/attribute.go
+++ b/o11y/otel/attribute.go
@@ -2,6 +2,7 @@ package otel
 
 import (
 	"fmt"
+	"reflect"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -28,7 +29,16 @@ func attr(key string, val any) attribute.KeyValue {
 		return attribute.Key(key).Float64(v)
 	default:
 		if s, ok := val.(fmt.Stringer); ok {
-			return attribute.Key(key).String(s.String())
+			interfaceVal := reflect.ValueOf(val)
+			switch interfaceVal.Kind() {
+			case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer,
+				reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+				if interfaceVal.IsNil() {
+					return attribute.Key(key).String("nil")
+				}
+			default:
+				return attribute.Key(key).String(s.String())
+			}
 		}
 		return attribute.Key(key).String(fmt.Sprintf("%v", v))
 	}

--- a/o11y/otel/otel_test.go
+++ b/o11y/otel/otel_test.go
@@ -144,6 +144,14 @@ func TestProvider(t *testing.T) {
 		})
 	})
 
+	t.Run("nil_pointer_field_value", func(t *testing.T) {
+		_, span := o11y.StartSpan(ctx, "a different span")
+		defer o11y.End(span, &err)
+
+		var timeVal *time.Time
+		span.AddRawField("time_val", timeVal)
+	})
+
 	poll.WaitOn(t, func(t poll.LogT) poll.Result {
 		if len(col.Spans()) > 0 {
 			return poll.Success()
@@ -151,9 +159,10 @@ func TestProvider(t *testing.T) {
 		return poll.Continue("spans never turned up")
 	})
 
-	assert.Check(t, cmp.Equal(len(col.spans), 1))
+	assert.Check(t, cmp.Equal(len(col.spans), 2))
 	assert.Check(t, cmp.Equal(col.spans[0].Attrs["app.cc_key"], "cc_val"))
 	assert.Check(t, cmp.Equal(col.spans[0].Attrs["app.p_key"], "p_val"))
+	assert.Check(t, cmp.Equal(col.spans[1].Attrs["time_val"], "nil"))
 }
 
 func TestConcurrentSpanAccess(t *testing.T) {


### PR DESCRIPTION
Prevent panics when using potentially nil pointer values as span fields