### PR TITLE
Use simple span processing in tests & otel logs

### DIFF
--- a/config/o11y/otel.go
+++ b/config/o11y/otel.go
@@ -24,6 +24,8 @@ type OtelConfig struct {
 
 	DisableText bool
 
+	Test bool
+
 	SampleTraces  bool
 	SampleKeyFunc func(map[string]interface{}) string
 	SampleRates   map[string]uint
@@ -71,6 +73,8 @@ func Otel(ctx context.Context, o OtelConfig) (context.Context, func(context.Cont
 		SampleTraces:  o.SampleTraces,
 		SampleKeyFunc: o.SampleKeyFunc,
 		SampleRates:   o.SampleRates,
+
+		Test: o.Test,
 
 		Metrics: mProv,
 	}

--- a/testing/testcontext/context.go
+++ b/testing/testcontext/context.go
@@ -18,6 +18,7 @@ func Background() context.Context {
 func newContext() context.Context {
 	cx, _, _ := o11y.Otel(context.Background(), o11y.OtelConfig{
 		Service: "test-service",
+		Test:    true,
 	})
 	return cx
 }

--- a/testing/testcontextotel/context.go
+++ b/testing/testcontextotel/context.go
@@ -35,6 +35,7 @@ func newContext() context.Context {
 			attribute.String("service.mode", "mode"),
 		},
 		Metrics: &statsd.NoOpClient{},
+		Test:    true,
 	})
 	if err != nil {
 		return context.Background()


### PR DESCRIPTION
Currently, in tests we miss spans that haven't been batched processed. In some tests this means all of them.

Provide a test option and configure it in the testcontexts. This option switches to simple span processing which immediately exports spans on end. 

It also implements a basic otel log