### PR TITLE
[EXEC-4719] Correct the limit output of max procs

### DIFF
--- a/rundef/maxprocs.go
+++ b/rundef/maxprocs.go
@@ -3,6 +3,7 @@ package rundef
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"go.uber.org/automaxprocs/maxprocs"
 
@@ -13,12 +14,17 @@ func MaxProcs(ctx context.Context) (err error) {
 	ctx, span := o11y.StartSpan(ctx, "rundef: max procs")
 	defer o11y.End(span, &err)
 
-	limit, err := maxprocs.Set(maxprocs.Min(1), maxprocs.Logger(func(s string, i ...interface{}) {
-		o11y.Log(ctx, fmt.Sprintf(s, i))
+	_, err = maxprocs.Set(maxprocs.Min(1), maxprocs.Logger(func(s string, i ...interface{}) {
+		// This allows sampling using the rundef namespace which is useful for agents
+		prefixed := fmt.Sprintf("rundef: %s", s)
+
+		o11y.Log(ctx, fmt.Sprintf(prefixed, i))
 	}))
 	if err != nil {
 		return err
 	}
+
+	limit := runtime.GOMAXPROCS(0)
 
 	span.AddField("limit", limit)
 	return err


### PR DESCRIPTION
The library returns an undo function, not the limit as the MEMLIMIT one does