### PR TITLE
[EXEC-4719] Remove error group from rundef.Defaults as not needed

### DIFF
--- a/rundef/rundef.go
+++ b/rundef/rundef.go
@@ -2,8 +2,7 @@ package rundef
 
 import (
 	"context"
-
-	"golang.org/x/sync/errgroup"
+	"errors"
 
 	"github.com/circleci/ex/o11y"
 )
@@ -14,13 +13,10 @@ func Defaults(ctx context.Context) (err error) {
 	ctx, span := o11y.StartSpan(ctx, "rundef: defaults")
 	defer o11y.End(span, &err)
 
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		return MemLimit(ctx)
-	})
-	eg.Go(func() error {
-		return MaxProcs(ctx)
-	})
-
-	return eg.Wait()
+	err = errors.Join(err,
+		MemLimit(ctx),
+		MaxProcs(ctx),
+	)
+	
+	return err
 }


### PR DESCRIPTION
The errgroup was not needed here, I just intended to handle the errors together. Join is a better fit 