### PR TITLE
Make the otel & http host names more consistent

### DIFF
--- a/config/o11y/otel.go
+++ b/config/o11y/otel.go
@@ -20,7 +20,9 @@ import (
 // OtelConfig contains all the things we need to configure for otel based instrumentation.
 type OtelConfig struct {
 	GrpcHostAndPort string
-	HTTPHostAndPort string
+
+	// HTTPTracesURL configures a host for exporting traces to http[s]://host[:port][/path]
+	HTTPTracesURL string
 
 	// HTTPAuthorization is the authorization token to send with http requests
 	HTTPAuthorization secret.String
@@ -65,7 +67,7 @@ func Otel(ctx context.Context, o OtelConfig) (context.Context, func(context.Cont
 
 	cfg := otel.Config{
 		GrpcHostAndPort:   o.GrpcHostAndPort,
-		HTTPHostAndPort:   o.HTTPHostAndPort,
+		HTTPTracesURL:     o.HTTPTracesURL,
 		HTTPAuthorization: o.HTTPAuthorization,
 		Dataset:           o.Dataset,
 		ResourceAttributes: []attribute.KeyValue{

--- a/o11y/httpmetrics/provider.go
+++ b/o11y/httpmetrics/provider.go
@@ -12,8 +12,8 @@ import (
 )
 
 type Config struct {
-	// BaseURL the URL to post metrics too
-	BaseURL string
+	// URL configures a host for exporting metrics to http[s]://host[:port][/path]
+	URL string
 	// AuthToken is included as a bearer token on requests
 	AuthToken secret.String
 	// GlobalTags are added to each metric. Be aware of high cardinality issues
@@ -64,7 +64,7 @@ func New(cfg Config) *Provider {
 		client: httpclient.New(
 			httpclient.Config{
 				Name:       cfg.ClientName,
-				BaseURL:    cfg.BaseURL,
+				BaseURL:    cfg.URL,
 				UserAgent:  fmt.Sprintf("%s, ex", cfg.ClientName),
 				AcceptType: httpclient.JSON,
 				Timeout:    time.Millisecond * 500,
@@ -159,7 +159,7 @@ func (m *Provider) Publish(ctx context.Context) {
 		return
 	}
 
-	err := m.client.Call(ctx, httpclient.NewRequest("PUT", "/metric",
+	err := m.client.Call(ctx, httpclient.NewRequest("PUT", "",
 		httpclient.Timeout(sendTimeout),
 		httpclient.Body(
 			struct {

--- a/o11y/httpmetrics/provider_test.go
+++ b/o11y/httpmetrics/provider_test.go
@@ -207,7 +207,7 @@ func TestProvider_Publish(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := Config{
-				BaseURL:    server.URL,
+				URL:        server.URL + "/metric",
 				AuthToken:  secret.String("foo"),
 				GlobalTags: nil,
 			}
@@ -291,7 +291,7 @@ func TestProvider_StartPublishLoop(t *testing.T) {
 				t.Cleanup(server.Close)
 
 				cfg := Config{
-					BaseURL:         server.URL,
+					URL:             server.URL + "/metric",
 					AuthToken:       secret.String("foo"),
 					GlobalTags:      nil,
 					PublishInterval: 50 * time.Millisecond,
@@ -318,7 +318,7 @@ func TestProvider_StartPublishLoop(t *testing.T) {
 				t.Cleanup(server.Close)
 
 				cfg := Config{
-					BaseURL:         server.URL,
+					URL:             server.URL + "/metric",
 					AuthToken:       secret.String("foo"),
 					GlobalTags:      nil,
 					PublishInterval: 10 * time.Minute, // long to prevent publish before close

--- a/o11y/otel/otel.go
+++ b/o11y/otel/otel.go
@@ -31,7 +31,9 @@ import (
 type Config struct {
 	Dataset         string
 	GrpcHostAndPort string
-	HTTPHostAndPort string
+
+	// HTTPTracesURL configures a host for exporting traces to http[s]://host[:port][/path]
+	HTTPTracesURL string
 
 	// HTTPAuthorization is the authorization token to send with http requests
 	HTTPAuthorization secret.String
@@ -69,8 +71,8 @@ func New(conf Config) (o11y.Provider, error) {
 		exporters = append(exporters, grpc)
 	}
 
-	if conf.HTTPHostAndPort != "" {
-		http, err := newHTTP(context.Background(), conf.HTTPHostAndPort, conf.Dataset, conf.HTTPAuthorization)
+	if conf.HTTPTracesURL != "" {
+		http, err := newHTTP(context.Background(), conf.HTTPTracesURL, conf.Dataset, conf.HTTPAuthorization)
 		if err != nil {
 			return nil, err
 		}

--- a/o11y/otel/otel_test.go
+++ b/o11y/otel/otel_test.go
@@ -55,21 +55,21 @@ func TestO11y(t *testing.T) {
 		{
 			name: "http",
 			cfg: o11yconfig.OtelConfig{
-				Dataset:         "local-testing",
-				HTTPHostAndPort: "http://127.0.0.1:4318",
-				Service:         "http-main",
-				Version:         "dev-test",
-				StatsNamespace:  "test-app",
+				Dataset:        "local-testing",
+				HTTPTracesURL:  "http://127.0.0.1:4318",
+				Service:        "http-main",
+				Version:        "dev-test",
+				StatsNamespace: "test-app",
 			},
 		},
 		{
 			name: "http with path",
 			cfg: o11yconfig.OtelConfig{
-				Dataset:         "local-testing",
-				HTTPHostAndPort: "http://127.0.0.1:4318/v1/traces",
-				Service:         "http-path-main",
-				Version:         "dev-test",
-				StatsNamespace:  "test-app",
+				Dataset:        "local-testing",
+				HTTPTracesURL:  "http://127.0.0.1:4318/v1/traces",
+				Service:        "http-path-main",
+				Version:        "dev-test",
+				StatsNamespace: "test-app",
 			},
 		},
 		{
@@ -77,7 +77,7 @@ func TestO11y(t *testing.T) {
 			name: "http with token",
 			cfg: o11yconfig.OtelConfig{
 				Dataset:           "local-testing",
-				HTTPHostAndPort:   "http://127.0.0.1:4318",
+				HTTPTracesURL:     "http://127.0.0.1:4318",
 				Service:           "http-token-main",
 				HTTPAuthorization: "my-token",
 				Version:           "dev-test",
@@ -169,7 +169,7 @@ func TestO11y_Auth(t *testing.T) {
 
 	cfg := o11yconfig.OtelConfig{
 		Dataset:           "local-testing",
-		HTTPHostAndPort:   srv.URL,
+		HTTPTracesURL:     srv.URL,
 		Service:           "http-token-main",
 		HTTPAuthorization: "my-token",
 		Version:           "dev-test",


### PR DESCRIPTION
This is not currently in use anywhere, so shouldn't cause any breakages 