### PR TITLE
Remove insecure flag from otel exporter

### DIFF
--- a/o11y/otel/otel.go
+++ b/o11y/otel/otel.go
@@ -148,7 +148,6 @@ func traceProvider(exporter sdktrace.SpanExporter, conf Config) *sdktrace.Tracer
 func newHTTP(ctx context.Context, endpoint, dataset string, token secret.String) (*otlptrace.Exporter, error) {
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpointURL(endpoint),
-		otlptracehttp.WithInsecure(),
 		// This header may be used by honeycomb ingestion pathways in the future, but
 		// it is not currently needed for how the collectors are currently set up, which
 		// expect a resource attribute instead.


### PR DESCRIPTION
The WithEndpointURL option figures out if insecure is required automatically. It was never intended to be used here 