### PR TITLE
Start using formal otel span kind

### DIFF
--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -462,7 +462,7 @@ func (c *Client) retryRequest(ctx context.Context, name string, r Request, newRe
 	attemptCounter := 0
 
 	attempt := func() (err error) {
-		ctx, span := o11y.StartSpan(ctx, name)
+		ctx, span := o11y.StartSpan(ctx, name, o11y.WithSpanKind(o11y.SpanKindClient))
 		defer o11y.End(span, &err)
 		before := time.Now()
 
@@ -608,7 +608,6 @@ func (r Request) decodeBody(resp *http.Response, success bool) error {
 
 func addReqToSpan(span o11y.Span, req *http.Request, attempt int) {
 	span.AddRawField("meta.type", "http_client")
-	span.AddRawField("span.kind", "Client")
 	span.AddRawField("http.scheme", req.URL.Scheme)
 	span.AddRawField("http.host", req.URL.Host)
 	span.AddRawField("http.target", req.URL.Path)

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -280,7 +280,6 @@ func TestClient_Call_Propagates(t *testing.T) {
 			"version":                             true,
 			"app.flatten":                         true,
 			"hc_tcl.meta.type":                    true,
-			"hc_tcl.span.kind":                    true,
 			"hc_tcl.http.url":                     true,
 			"hc_tcl.http.request_content_length":  true,
 			"hc_tcl.http.base_url":                true,

--- a/o11y/honeycomb/honeycomb.go
+++ b/o11y/honeycomb/honeycomb.go
@@ -307,7 +307,7 @@ func (h *honeycomb) AddGlobalField(key string, val interface{}) {
 	client.AddField(key, val)
 }
 
-func (h *honeycomb) StartSpan(ctx context.Context, name string) (context.Context, o11y.Span) {
+func (h *honeycomb) StartSpan(ctx context.Context, name string, _ ...o11y.SpanOpt) (context.Context, o11y.Span) {
 	span := trace.GetSpanFromContext(ctx)
 	var newSpan *trace.Span
 	if span != nil {
@@ -373,7 +373,7 @@ func (h *honeycomb) Helpers(disableW3c ...bool) o11y.Helpers {
 
 func (h *honeycomb) StartGoldenTrace(ctx context.Context, _ string) context.Context { return ctx }
 func (h *honeycomb) EndGoldenTrace(ctx context.Context)                             {}
-func (h *honeycomb) StartGoldenSpan(ctx context.Context, _ string) (context.Context, o11y.Span) {
+func (h *honeycomb) StartGoldenSpan(ctx context.Context, _ string, _ ...o11y.SpanOpt) (context.Context, o11y.Span) {
 	return ctx, nil
 }
 
@@ -411,7 +411,9 @@ func (h helpers) ExtractPropagation(ctx context.Context) o11y.PropagationContext
 
 // InjectPropagation adds propagation info into the ctx from p which will have been populated by other packages
 // that receive trace propagation data from other systems.
-func (h helpers) InjectPropagation(ctx context.Context, p o11y.PropagationContext) (context.Context, o11y.Span) {
+func (h helpers) InjectPropagation(ctx context.Context,
+	p o11y.PropagationContext, _ ...o11y.SpanOpt) (context.Context, o11y.Span) {
+
 	var prop *propagation.PropagationContext
 
 	field := p.Parent

--- a/o11y/httpmetrics/provider_test.go
+++ b/o11y/httpmetrics/provider_test.go
@@ -4,15 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
 
 	"github.com/circleci/ex/config/secret"
 	"github.com/circleci/ex/testing/fakemetricrec"
 	"github.com/circleci/ex/testing/testcontext"
-
-	"golang.org/x/sync/errgroup"
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 )
 
 func TestProvider_Record(t *testing.T) {

--- a/o11y/spanopt.go
+++ b/o11y/spanopt.go
@@ -1,0 +1,27 @@
+package o11y
+
+type SpanConfig struct {
+	Kind SpanKind
+}
+
+type SpanOpt func(SpanConfig) SpanConfig
+
+// WithSpanKind sets the SpanKind of a Span.
+func WithSpanKind(kind SpanKind) SpanOpt {
+	return func(cfg SpanConfig) SpanConfig {
+		cfg.Kind = kind
+		return cfg
+	}
+}
+
+// SpanKind is the role a Span plays in a Trace.
+type SpanKind int
+
+// These are direct copies of the otel values - see them for documentation
+const (
+	SpanKindInternal SpanKind = 1
+	SpanKindServer   SpanKind = 2
+	SpanKindClient   SpanKind = 3
+	SpanKindProducer SpanKind = 4
+	SpanKindConsumer SpanKind = 5
+)

--- a/rabbit/publisherpool.go
+++ b/rabbit/publisherpool.go
@@ -66,7 +66,7 @@ func (p *PublisherPool) Close(ctx context.Context) (err error) {
 // Publish allows the publication of a message with mandatory routing.
 // This should be your preferred option over PublishOptional
 func (p *PublisherPool) Publish(ctx context.Context, msg publisher.Message) (err error) {
-	ctx, span := o11y.StartSpan(ctx, "pool: publish")
+	ctx, span := o11y.StartSpan(ctx, "pool: publish", o11y.WithSpanKind(o11y.SpanKindProducer))
 	defer o11y.End(span, &err)
 	span.AddField("exchange", msg.Exchange)
 	span.AddField("key", msg.Key)

--- a/rabbit/publisherpool_test.go
+++ b/rabbit/publisherpool_test.go
@@ -230,7 +230,7 @@ func setupConsumer(ctx context.Context, t *testing.T, consumerDialer *amqpextra.
 		consumer.WithContext(ctx),
 		consumer.WithQueue(queueName),
 		consumer.WithHandler(consumer.HandlerFunc(func(ctx context.Context, msg amqp.Delivery) interface{} {
-			ctx, span := o11y.StartSpan(ctx, "testconsumer")
+			ctx, span := o11y.StartSpan(ctx, "testconsumer", o11y.WithSpanKind(o11y.SpanKindConsumer))
 			defer span.End()
 			body := string(msg.Body)
 			received.Store(body, true)

--- a/rundef/automem_test.go
+++ b/rundef/automem_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
-	"gotest.tools/v3/assert/cmp"
-
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 
 	"github.com/circleci/ex/testing/testcontext"

--- a/rundef/rundef.go
+++ b/rundef/rundef.go
@@ -17,6 +17,6 @@ func Defaults(ctx context.Context) (err error) {
 		MemLimit(ctx),
 		MaxProcs(ctx),
 	)
-	
+
 	return err
 }


### PR DESCRIPTION
The variadic options stle API is a bit verbose, but avoids a break to the API and is generally only going to be used in library code, so should have minimal impact on day to day use of spans.

(managed to drag in some linter fixups somehow)