### PR TITLE
[EXEC-4742] Add aws request ID header values to the trace for debugging

### DIFF
--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -629,6 +629,12 @@ func addRespToSpan(span o11y.Span, res *http.Response) {
 	if ce := res.Header.Get("Content-Encoding"); ce != "" {
 		span.AddRawField("http.response_content_encoding", ce)
 	}
+	if rID := res.Header.Get("x-amz-request-id"); rID != "" {
+		span.AddRawField("http.amz_request_id", rID)
+	}
+	if rID2 := res.Header.Get("x-amz-id-2"); rID2 != "" {
+		span.AddRawField("http.amz_id_2", rID2)
+	}
 	span.AddRawField("http.status_code", res.StatusCode)
 }
 


### PR DESCRIPTION
The amazon support folks need request IDs (they sent [this link](https://docs.aws.amazon.com/AmazonS3/latest/API/get-request-ids.html)) to continue their deep dive into failed downloads of the oidc plugin. 

This seems like the most straightforward way to get them correlated with a bad download.