### PR TITLE
Don't include internal baggage as span attributes

### DIFF
--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -278,7 +278,6 @@ func TestClient_Call_Propagates(t *testing.T) {
 		expected := map[string]bool{
 			"service":                             true,
 			"version":                             true,
-			"app.flatten":                         true,
 			"hc_tcl.meta.type":                    true,
 			"hc_tcl.http.url":                     true,
 			"hc_tcl.http.request_content_length":  true,
@@ -287,7 +286,6 @@ func TestClient_Call_Propagates(t *testing.T) {
 			"hc_tcl.http.retry":                   true,
 			"hc_tcl.result":                       true,
 			"hc_tcl.flattened":                    true,
-			"hc_tcl.app.flatten":                  true,
 			"hc_tcl.http.client_name":             true,
 			"hc_tcl.duration_ms":                  true,
 			"hc_tcl.http.attempt":                 true,

--- a/o11y/o11y.go
+++ b/o11y/o11y.go
@@ -313,6 +313,9 @@ type Baggage map[string]string
 func (b Baggage) addToTrace(ctx context.Context) {
 	o := FromContext(ctx)
 	for k, v := range b {
+		if isInternalBaggage(k) {
+			continue
+		}
 		k := strings.ReplaceAll(k, "-", "_")
 		o.AddFieldToTrace(ctx, k, v)
 	}
@@ -467,6 +470,16 @@ func AddExtrasToBaggage(ctx context.Context, flatten int, gold http.Header) cont
 		return ctx
 	}
 	return WithBaggage(ctx, bag)
+}
+
+func isInternalBaggage(key string) bool {
+	if key == flattenDepthBaggageKey {
+		return true
+	}
+	if strings.HasPrefix(key, goldenTracePrefix) {
+		return true
+	}
+	return false
 }
 
 type rollbarAble interface {


### PR DESCRIPTION
This clutters the telemetry 