### PR TITLE
Allow providing an attempt timeout for latest release download

### DIFF
--- a/testing/releases/latest.go
+++ b/testing/releases/latest.go
@@ -22,6 +22,8 @@ type DownloadConfig struct {
 	Pinned string
 	// Dir is the directory to download into, if empty will default to ../bin
 	Dir string
+	// AttemptTimeout is the maximum amount of time for a single download attempt
+	AttemptTimeout time.Duration
 }
 
 // DownloadLatest is a helper that will download the latest test binary
@@ -62,7 +64,8 @@ func DownloadLatest(ctx context.Context, conf DownloadConfig) (string, error) {
 		conf.Dir = "../bin"
 	}
 
-	dl, err := download.NewDownloader(time.Minute, conf.Dir)
+	dl, err := download.NewDownloader(time.Minute, conf.Dir,
+		download.AttemptTimeout(conf.AttemptTimeout))
 	if err != nil {
 		return "", fmt.Errorf("download failed: %w", err)
 	}

--- a/testing/releases/releases_test.go
+++ b/testing/releases/releases_test.go
@@ -48,6 +48,11 @@ d7045e25ab522bdc057b6626e7a566409b369d65836cc1cd4e16038c2f4cb573 *linux/arm/publ
 dd6c2a3230952f4cec6190ca030372a3a1a6d04d6d483d81bb06c506032b0eba *windows/amd64/internal.exe
 2986031acbd08d930c06131e64f68fe9c32fdaac32d028e53f178afc2dd4889b *windows/amd64/public.exe
 3064327451adf87ed823410e23837a2843f1cb823480be3909db91ef85c79141 *windows/amd64/receiver.exe
+67f0361eca538aee7708be61b6f0d84aeece5634af5b35a09c0c80b40712e675 *darwin/amd64/slow
+67f0361eca538aee7708be61b6f0d84aeece5634af5b35a09c0c80b40712e675 *darwin/arm64/slow
+67f0361eca538aee7708be61b6f0d84aeece5634af5b35a09c0c80b40712e675 *linux/amd64/slow
+67f0361eca538aee7708be61b6f0d84aeece5634af5b35a09c0c80b40712e675 *linux/arm64/slow
+67f0361eca538aee7708be61b6f0d84aeece5634af5b35a09c0c80b40712e675 *windows/amd64/slow.exe
 `
 
 func TestReleases_ResolveURL(t *testing.T) {
@@ -137,12 +142,14 @@ func TestReleases_ResolveURLs(t *testing.T) {
 				"internal": baseURL + "internal",
 				"public":   baseURL + "public",
 				"receiver": baseURL + "receiver",
+				"slow":     baseURL + "slow",
 			}
 			if tt.OS == "windows" {
 				expect = map[string]string{
 					"internal": baseURL + "internal.exe",
 					"public":   baseURL + "public.exe",
 					"receiver": baseURL + "receiver.exe",
+					"slow":     baseURL + "slow.exe",
 				}
 			}
 			assert.Check(t, cmp.DeepEqual(urls, expect))


### PR DESCRIPTION
Found a failed download of the E2E binary [here](https://app.circleci.com/pipelines/github/circleci/build-agent/33719/workflows/94bf3942-c6ac-4d0d-9ced-d0756d208d2c/jobs/259545/tests#failed-test-0), so I'm adding the ability to pass through an attempt timeout to the underlying downloader in the `releases.DownloadLatest` call.