### PR TITLE
Remove GET with Body support now RT-724 is complete

### DIFF
--- a/releases/release/handler_test.go
+++ b/releases/release/handler_test.go
@@ -19,81 +19,6 @@ import (
 	"github.com/circleci/ex/testing/testcontext"
 )
 
-func TestHandler_WithBody(t *testing.T) {
-	ctx := testcontext.Background()
-
-	t.Run("Test success", func(t *testing.T) {
-		fix := startAPI(ctx, t)
-
-		t.Run("Can get a release", func(t *testing.T) {
-			agent, err := fix.DownloadWithBody(ctx, release.Requirements{
-				Platform: "linux",
-				Arch:     "amd64",
-			})
-
-			assert.Assert(t, err)
-			assert.Check(t, cmp.DeepEqual(agent, &release.Release{
-				URL:      fix.S3URL + "/1.1.1-abcdef01/linux/amd64/circleci-agent",
-				Checksum: "4a62f09b64873a20386cdbfaca87cc10d8352fab014ef0018f1abcce08a3d027",
-				Version:  "1.1.1-abcdef01",
-			}))
-		})
-	})
-
-	t.Run("Test for unknown arch", func(t *testing.T) {
-		fix := startAPI(ctx, t)
-
-		t.Run("Release not found", func(t *testing.T) {
-			_, err := fix.DownloadWithBody(ctx, release.Requirements{
-				Platform: "linux",
-				Arch:     "enemy",
-			})
-			assert.Check(t, httpclient.HasStatusCode(err, http.StatusNotFound))
-			assert.Check(t, cmp.ErrorContains(err,
-				`404 (Not Found) (1 attempts): no download found for version="1.1.1-abcdef01" os="linux" arch="enemy"`,
-			))
-		})
-	})
-
-	t.Run("Test invalid requests", func(t *testing.T) {
-		fix := startAPI(ctx, t)
-
-		t.Run("No platform", func(t *testing.T) {
-			_, err := fix.DownloadWithBody(ctx, release.Requirements{
-				Arch: "enemy",
-			})
-			assert.Check(t, httpclient.HasStatusCode(err, http.StatusBadRequest))
-			assert.Check(t, cmp.ErrorContains(err,
-				`400 (Bad Request) (1 attempts): bad request: platform is required`,
-			))
-		})
-		t.Run("No arch", func(t *testing.T) {
-			_, err := fix.DownloadWithBody(ctx, release.Requirements{
-				Platform: "linux",
-			})
-			assert.Check(t, httpclient.HasStatusCode(err, http.StatusBadRequest))
-			assert.Check(t, cmp.ErrorContains(err,
-				`400 (Bad Request) (1 attempts): bad request: arch is required`,
-			))
-		})
-	})
-
-	t.Run("Test no downloads", func(t *testing.T) {
-		fix := startAPIWithDownloads(ctx, t, false)
-
-		t.Run("Should give 410", func(t *testing.T) {
-			_, err := fix.DownloadWithBody(ctx, release.Requirements{
-				Platform: "linux",
-				Arch:     "amd64",
-			})
-			assert.Check(t, httpclient.HasStatusCode(err, http.StatusGone))
-			assert.Check(t, cmp.ErrorContains(err,
-				`410 (Gone) (1 attempts): no more downloads possible`,
-			))
-		})
-	})
-}
-
 func TestHandler_WithQuery(t *testing.T) {
 	ctx := testcontext.Background()
 
@@ -167,10 +92,6 @@ func TestHandler_WithQuery(t *testing.T) {
 			))
 		})
 	})
-}
-
-func (f *fixture) DownloadWithBody(ctx context.Context, requirements release.Requirements) (*release.Release, error) {
-	return f.download(ctx, httpclient.Body(requirements), httpclient.AllowGETWithBody())
 }
 
 func (f *fixture) DownloadWithQuery(ctx context.Context, requirements release.Requirements) (*release.Release, error) {


### PR DESCRIPTION
This removes the dual-path code we had for allowing HTTP GET requests with bodies as well as parameters. Now we are behind WAF and RT-724 is complete we can remove the dual-path and streamline.

This fixes another issue where the release handler will return an error and the value, rather than returning during the error.