### PR TITLE
Rename the host tag from http metrics

### DIFF
--- a/httpclient/metrics/metrics.go
+++ b/httpclient/metrics/metrics.go
@@ -227,7 +227,7 @@ func (r *request) gotCon(info httptrace.GotConnInfo) {
 	}
 	r.conDoneAt = time.Now()
 
-	commonTags := append(r.commonTags, "host:"+r.con.host)
+	commonTags := append(r.commonTags, "hostport:"+r.con.host)
 
 	tags := map[string]string{
 		"reused":  "false",


### PR DESCRIPTION
'host' is reserved and it clutters the host maps / host lists in DD (and it is possible we are charged for them as a host (tbc))

<img width="469" alt="Screenshot 2025-03-05 at 15 30 56" src="https://github.com/user-attachments/assets/5140f829-a3e4-410c-976f-56aac8a3bab1" />


This will mes with a few dashboards - but should not be used in any alerts

<img width="973" alt="Screenshot 2025-03-05 at 15 28 15" src="https://github.com/user-attachments/assets/a35ad6ed-fdd1-4cff-94d0-adc0420bc038" />

I'll fixup where I find them in dashboards