### PR TITLE
make duration_ms available in samplekeyfunc for otel

### DIFF
--- a/config/o11y/otel_test.go
+++ b/config/o11y/otel_test.go
@@ -17,29 +17,28 @@ func TestSetup(t *testing.T) {
 	s := fakestatsd.New(t)
 
 	ctx := context.Background()
-	ctx, cleanup, err := o11yconfig.Setup(ctx, o11yconfig.Config{
+	ctx, cleanup, err := o11yconfig.Otel(ctx, o11yconfig.OtelConfig{
 		Statsd:            s.Addr(),
 		RollbarToken:      "qwertyuiop",
 		RollbarDisabled:   true,
 		RollbarEnv:        "production",
 		RollbarServerRoot: "github.com/circleci/ex",
-		HoneycombEnabled:  false,
-		HoneycombDataset:  "does-not-exist",
-		HoneycombKey:      "1234567890",
 		SampleTraces:      false,
-		Format:            "color",
+		Test:              true,
 		Version:           "1.2.3",
 		Service:           "test-service",
 		StatsNamespace:    "test.service",
 		Mode:              "banana",
-		Debug:             true,
 	})
 	assert.Assert(t, err)
 
-	t.Run("Send metric", func(t *testing.T) {
+	t.Run("Add some telemetry", func(t *testing.T) {
 		p := o11y.FromContext(ctx)
 		err = p.MetricsProvider().Count("my_count", 1, []string{"mytag:myvalue"}, 1)
 		assert.Check(t, err)
+
+		_, sp := p.StartSpan(ctx, "my_span")
+		sp.End()
 	})
 
 	t.Run("Cleanup provider", func(t *testing.T) {

--- a/o11y/otel/otel_test.go
+++ b/o11y/otel/otel_test.go
@@ -527,6 +527,9 @@ func TestSampling(t *testing.T) {
 			GrpcHostAndPort: lis.Addr().String(),
 			SampleTraces:    true,
 			SampleKeyFunc: func(m map[string]any) string {
+				if _, ok := m["duration_ms"].(int); !ok {
+					t.Error("duration_ms is not an int or does not exist")
+				}
 				return fmt.Sprintf("%s", m["name"])
 			},
 			SampleRates: map[string]uint{

--- a/o11y/otel/sampler.go
+++ b/o11y/otel/sampler.go
@@ -18,6 +18,8 @@ func (s deterministicSampler) shouldSample(p sdktrace.ReadOnlySpan) (bool, uint)
 	for _, attr := range p.Attributes() {
 		fields[string(attr.Key)] = attr.Value.AsInterface()
 	}
+	// fields used in the existing sample key func
+	fields["duration_ms"] = int(p.EndTime().Sub(p.StartTime()).Milliseconds())
 	fields["name"] = p.Name()
 
 	key := s.sampleKeyFunc(fields)


### PR DESCRIPTION
the config test change is incidental - i just noticed it was not testing otel setup :| 