### PR TITLE
Option to disable tail sampling

### DIFF
--- a/config/o11y/otel.go
+++ b/config/o11y/otel.go
@@ -31,6 +31,9 @@ type OtelConfig struct {
 	// UseEnvironments will cause spans to be sent to the new honeycomb environments
 	UseEnvironments bool
 
+	// This will tell the collectors to bypass the server side tail based sampler
+	DisableTailSampling bool
+
 	// DisableText prevents output to stdout for noisy services. Ignored if no other no hosts are supplied
 	DisableText bool
 
@@ -124,6 +127,9 @@ func (o *OtelConfig) otel() otel.Config {
 	}
 	if o.UseEnvironments {
 		cfg.ResourceAttributes = append(cfg.ResourceAttributes, attribute.Bool("meta.environments", true))
+	}
+	if o.DisableTailSampling {
+		cfg.ResourceAttributes = append(cfg.ResourceAttributes, attribute.Bool("meta.sampling.disabled", true))
 	}
 	return cfg
 }

--- a/o11y/otel/otel_test.go
+++ b/o11y/otel/otel_test.go
@@ -206,11 +206,12 @@ func TestProvider(t *testing.T) {
 	defer grpcServer.Stop()
 
 	ctx, closeProvider, err := o11yconfig.Otel(context.Background(), o11yconfig.OtelConfig{
-		Service:         "app-main",
-		Version:         "dev-test",
-		Dataset:         "execyooshun",
-		GrpcHostAndPort: lis.Addr().String(),
-		StatsNamespace:  "test-app",
+		Service:             "app-main",
+		Version:             "dev-test",
+		Dataset:             "execyooshun",
+		GrpcHostAndPort:     lis.Addr().String(),
+		StatsNamespace:      "test-app",
+		DisableTailSampling: true,
 	})
 	assert.NilError(t, err)
 	defer closeProvider(ctx)
@@ -246,6 +247,7 @@ func TestProvider(t *testing.T) {
 	assert.Check(t, cmp.Equal(len(col.spans), 1))
 	assert.Check(t, cmp.Equal(col.spans[0].Attrs["app.cc_key"], "cc_val"))
 	assert.Check(t, cmp.Equal(col.spans[0].Attrs["app.p_key"], "p_val"))
+	assert.Check(t, cmp.Equal(col.resourceAttr["meta.sampling.disabled"], "true"))
 }
 
 func TestConcurrentSpanAccess(t *testing.T) {


### PR DESCRIPTION
this resource attribute will be used to skip refinery in the otelcollector - pr upcoming