### PR TITLE
Disable automaxprocs on Go 1.25+

### DIFF
--- a/rundef/maxprocs.go
+++ b/rundef/maxprocs.go
@@ -1,3 +1,5 @@
+//go:build !go1.25
+
 package rundef
 
 import (

--- a/rundef/maxprocs_go125.go
+++ b/rundef/maxprocs_go125.go
@@ -1,0 +1,21 @@
+//go:build go1.25
+
+package rundef
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/circleci/ex/o11y"
+)
+
+// MaxProcs is a no-op on Go 1.25+
+func MaxProcs(ctx context.Context) (err error) {
+	ctx, span := o11y.StartSpan(ctx, "rundef: max procs")
+	defer o11y.End(span, &err)
+
+	limit := runtime.GOMAXPROCS(0) // Get the limit the go runtime has determined
+
+	span.AddField("limit", limit)
+	return err
+}

--- a/rundef/maxprocs_test.go
+++ b/rundef/maxprocs_test.go
@@ -1,3 +1,5 @@
+//go:build !go1.25
+
 package rundef
 
 import (


### PR DESCRIPTION
Cribbed from: https://github.com/circleci/backplane-go/pull/549