### PR TITLE
Use meta.keep.span for DisableTailSampling

### DIFF
--- a/config/o11y/otel.go
+++ b/config/o11y/otel.go
@@ -154,7 +154,7 @@ func (o *OtelConfig) ToOTEL() otel.Config {
 		cfg.ResourceAttributes = append(cfg.ResourceAttributes, attribute.Bool("meta.environments", true))
 	}
 	if o.DisableTailSampling {
-		cfg.ResourceAttributes = append(cfg.ResourceAttributes, attribute.Bool("meta.sampling.disabled", true))
+		cfg.ResourceAttributes = append(cfg.ResourceAttributes, attribute.Bool("meta.keep.span", true))
 	}
 	return cfg
 }

--- a/o11y/otel/otel_test.go
+++ b/o11y/otel/otel_test.go
@@ -260,7 +260,7 @@ func TestProvider(t *testing.T) {
 	assert.Check(t, cmp.Equal(len(col.spans), 1))
 	assert.Check(t, cmp.Equal(col.spans[0].Attrs["app.cc_key"], "cc_val"))
 	assert.Check(t, cmp.Equal(col.spans[0].Attrs["app.p_key"], "p_val"))
-	assert.Check(t, cmp.Equal(col.resourceAttr["meta.sampling.disabled"], "true"))
+	assert.Check(t, cmp.Equal(col.resourceAttr["meta.keep.span"], "true"))
 }
 
 func TestConcurrentSpanAccess(t *testing.T) {


### PR DESCRIPTION
`meta.sampling.disabled` seems to have disappeared. Use `meta.keep.span` now