### PR TITLE
Add round-robin load balancing to OTel gRPC exporter

### DIFF
--- a/o11y/otel/otel.go
+++ b/o11y/otel/otel.go
@@ -201,6 +201,7 @@ func newGRPC(ctx context.Context, endpoint string) (*otlptrace.Exporter, error) 
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(endpoint),
 		otlptracegrpc.WithInsecure(),
+		otlptracegrpc.WithServiceConfig(`{"loadBalancingConfig":[{"round_robin":{}}]}`),
 	}
 	return otlptrace.New(ctx, otlptracegrpc.NewClient(opts...))
 }


### PR DESCRIPTION
Without a load balancing policy, the gRPC client defaults to `pick_first` — it picks one address from DNS and never uses the others. This means each pod connects to a single OTel collector even when the collector hostname resolves to multiple IPs (e.g. a k8s deployment behind a headless service).

Adding `round_robin` matches the pattern already used in `grpc/dial.go` for gRPC service clients, and mirrors what backplane-go does for its OTel exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)